### PR TITLE
Specify radio.DAE as starting with a lowercase letter like the file does

### DIFF
--- a/index.vwf.yaml
+++ b/index.vwf.yaml
@@ -112,7 +112,7 @@ children:
       radio:
         extends: http://vwf.example.com/node3.vwf
         implements: [ "source/inventoriable.vwf" ]
-        source: assets/3d/Radio/Radio.DAE
+        source: assets/3d/Radio/radio.DAE
         type: model/vnd.collada+xml
         properties:
           iconSrc: "../assets/images/radio.png"


### PR DESCRIPTION
This is required for it to work right on linux servers which are case-sensitive.

@kadst43, @scottnc27603, or @BrettASwift would you mind reviewing?
