### PR TITLE
fix-pickup-success

### DIFF
--- a/source/inventory.vwf.yaml
+++ b/source/inventory.vwf.yaml
@@ -34,11 +34,12 @@ scripts: |
         this.swap( this.slots.indexOf( objectID ), index );
         return;
       }
-      object.pickedUp();
+
       object.parent_ = this;
       this.slots[ index ] = object.name;
       object.visible = this.inventoryIsVisible;
-      
+      object.pickedUp();
+
     }
 
   }
@@ -63,9 +64,9 @@ scripts: |
     if ( object && object.parent === this ) {
 
       object.parent_ = this.find( "//pickups" )[ 0 ];
-      object.dropped();
       this.slots[ this.slots.indexOf( objectID ) ] = undefined;
       object.visible = true;
+      object.dropped();
       
     }
 


### PR DESCRIPTION
@kadst43 @eric79 @scottnc27603 This fixes the bug where the scenario doesn't succeed when picking up the radio after already being on the goal square. The success check was happening before the radio was added to the rover. The pickedUp event now correctly fires after the object hierarchy has changed. Also moved the dropped event just in case.
