### PR TITLE
Stops blockly execution when the scenario fails

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -71,7 +71,6 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
         // nodeID is ignored here?
         if ( eventName === "failed" ) {
 
-            vwf_view.kernel.callMethod( vwf_view.kernel.application(), "stopAllExecution", [ true ] );
             endScenario( "failure" );
 
         }

--- a/source/scenario.js
+++ b/source/scenario.js
@@ -75,6 +75,9 @@ this.checkForSuccess = function() {
 
 this.checkForFailure = function() {
     if ( checkFailedFn && checkFailedFn() ) {
+        if ( scene ) {
+            scene.stopAllExecution();
+        }
         self.failed();
     }
 }


### PR DESCRIPTION
@eric79 
Stop all blockly items from executing when a failure is reached.
