### PR TITLE
Correct the rover's starting position on the game map

### DIFF
--- a/index.vwf.yaml
+++ b/index.vwf.yaml
@@ -170,7 +170,7 @@ children:
           rotation: [ 0, 0, 1, 270 ]
           castShadows: true
           receiveShadows: true
-          currentGridSquare: [ 0, 7 ]
+          currentGridSquare: [ 2, 7 ]
           heading: 270
           terrainName: "terrain"
           blockly_allowedBlocks: 10
@@ -204,7 +204,7 @@ children:
       castShadows: true
       receiveShadows: true
       blocklyEnabled: false
-      currentGridSquare: [ 0, 8 ]
+      currentGridSquare: [ 2, 8 ]
       heading: 270
       terrainName: "terrain"
     children:


### PR DESCRIPTION
@kadst43 , I decided just to make this really quick fix to the rover position on the boundary map so that we can be ready for the IPR tomorrow.  We can refactor it so that it is automatically calculated from the rover's position and the position/gridSize of the `boundaryMap` (and then set the rover position inside the scenario file) in a separate pull request.

Would you or @scottnc27603, or @BrettASwift, or @ajiraffe mind reviewing?
