### PR TITLE
Remove minirover HUD generation

### DIFF
--- a/source/hudInstructions.js
+++ b/source/hudInstructions.js
@@ -1,7 +1,6 @@
 function createHUD() {
 
     createRoverElement();
-    createMiniRoverElement();
     createCameraSelector();
     createCommsDisplay();
 


### PR DESCRIPTION
@ajiraffe @kadst43 @scottnc27603 Removed the minirover HUD element since the minirover is gone for now. When the minirover is added back in, we need to create that element when it is added.
