### PR TITLE
Fixed timing issue causing camera not to initialize properly

### DIFF
--- a/source/camera.js
+++ b/source/camera.js
@@ -1,4 +1,4 @@
-var durationSeconds = 1;
+var durationSeconds = 0;
 var delaySeconds = 0.1;
 var self = this;
 var cachedTargetNode;
@@ -9,6 +9,7 @@ this.initialize = function() {
 
 this.onSceneReady$ = function() {
     setTargetEventHandler();
+    durationSeconds = 1;
 }
 
 this.changePointOfView$ = function( newPointOfView ) {


### PR DESCRIPTION
This will fix the camera not being set properly on start up. It was happening because the `transformTo` calls were executing over a second, causing them to overwrite the value set by `followTarget$`.
