### PR TITLE
fix-scenario-loading

### DIFF
--- a/source/triggers/booleanFunctionFactory.js
+++ b/source/triggers/booleanFunctionFactory.js
@@ -318,7 +318,7 @@ this.clauseSet.onScenarioStart = function( params, context, callback ) {
 
     onClauseCallbackWarning( callback );
     if ( callback ) {
-        var scenario = self.findTypeInContext( context, "source/scenario.vwf" );
+        var scenario = self.findInContext( context, context.activeScenarioPath );
 
         if ( scenario ) {
             scenario.entering = self.events.add( function( startingName ) {


### PR DESCRIPTION
I can't verify that this is a complete fix, unfortunately. This does prevent the find from returning multiple scenarios and having to do guesswork as to which one it was supposed to find.

I see there is an optional scenario name parameter for `onScenarioStart`, but I can't find the call for that anywhere. That might be better than accessing `context.activeScenarioPath`. Any thoughts @kadst43?
