### PR TITLE
Make blockly textarea display none on drag

### DIFF
--- a/source/blocklyUI.js
+++ b/source/blocklyUI.js
@@ -12,6 +12,7 @@ function setUpBlocklyPeripherals() {
         handle: "div#blocklyHandle",
         scroll: false,
         drag: function( event, element ) {
+            $( ".blocklyWidgetDiv" ).css( "display", "none" );
             var width = element.helper.context.clientWidth;
             var height = element.helper.context.clientHeight;
             var offscreenAllowanceWidth = width * 0.85;


### PR DESCRIPTION
Not vital, but makes the text box for blockly numbers disappear when dragging the blockly interface, so it doesn't look like it gets left behind.
