### PR TITLE
Change incomplete program trigger conditions

### DIFF
--- a/source/scenario/scenario1.vwf.yaml
+++ b/source/scenario/scenario1.vwf.yaml
@@ -93,14 +93,21 @@ properties:
       - onBlocklyStopped:
       additionalCondition:
       - not:
-        - and:
-          - isAtPosition:
+        - or:
+          - and:
+            - isAtPosition:
+              - rover
+              - 8
+              - 16
+            - hasObject:
+              - rover
+              - radio
+          - moveFailed:
             - rover
-            - 8
-            - 16
-          - hasObject:
+            - collision
+          - moveFailed:
             - rover
-            - radio
+            - battery
       actions:
       - scenarioFailure:
         - "You didn't reach the destination!"


### PR DESCRIPTION
@kadst43 Changes the additional conditions for the incomplete program trigger to disallow `movefailed` so the correct popups occur. One thing is that if the entire program takes the rover to 0 battery, and no further, then the incomplete program popup will show, since the battery movefailed happens on moving with 0 battery. This could be something to change, but I think it is fine as it is.
