### PR TITLE
Soliciting Feedback : Fixing Double Failure

### DIFF
--- a/source/scenario/scenario1.vwf.yaml
+++ b/source/scenario/scenario1.vwf.yaml
@@ -82,6 +82,8 @@ properties:
         - rover
         - collision
       actions:
+      - writeToBlackboard:
+        - hasFailed
       - scenarioFailure:        
         - collision
       - playSound:
@@ -97,6 +99,8 @@ properties:
         - rover
         - battery
       actions:
+      - writeToBlackboard:
+        - hasFailed
       - scenarioFailure:         
         - battery
       - playSound:
@@ -110,16 +114,22 @@ properties:
       triggerCondition:
       - onBlocklyStopped:
       additionalCondition:
-      - not:
-        - and:
-          - isAtPosition:
-            - rover
-            - 8
-            - 16
-          - hasObject:
-            - rover
-            - radio
+      - and:
+        - not:
+          - and:
+            - isAtPosition:
+              - rover
+              - 8
+              - 16
+            - hasObject:
+              - rover
+              - radio
+        - not:
+          - readBlackboard:
+            - hasFailed
       actions:
+      - writeToBlackboard:
+        - hasFailed
       - scenarioFailure:
         - incomplete
       - playSound:
@@ -159,6 +169,8 @@ properties:
         - environmentWind
       - writeToBlackboard:
         - musicStoryScreen
+      - clearBlackboard:
+        - hasFailed
 
     playStartingSounds:
       triggerCondition:

--- a/source/triggers/actionFactory.js
+++ b/source/triggers/actionFactory.js
@@ -135,10 +135,25 @@ this.actionSet.writeToBlackboard = function( params, context ) {
         return undefined;
     }
 
-    var blackboard = context.sceneBlackboard;
+    var scene = self.find( "/" )[ 0 ];
 
     return function() {
-        blackboard[ params[ 0 ] ] = 1;
+        scene.sceneBlackboard[ params[ 0 ] ] = 1;
+    }
+
+}
+
+this.actionSet.clearBlackboard = function( params, context ) {
+
+    if ( params && ( params.length < 1 ) ) {
+        self.logger.errorx( "clearBlackboard", "This action takes one parameter: variable name.");
+        return undefined;
+    }
+
+    var scene = self.find( "/" )[ 0 ];
+
+    return function() {
+        scene.sceneBlackboard[ params[ 0 ] ] = undefined;
     }
 
 }
@@ -150,13 +165,13 @@ this.actionSet.incrementBlackboardValue = function( params, context ) {
         return undefined;
     }
 
-    var blackboard = context.sceneBlackboard;
+    var scene = self.find( "/" )[ 0 ];
 
     return function() {
-        if ( !blackboard[ params[ 0 ] ] ){
-            blackboard[ params[ 0 ] ] = 1;
+        if ( !scene.sceneBlackboard[ params[ 0 ] ] ){
+            scene.sceneBlackboard[ params[ 0 ] ] = 1;
         } else {
-            blackboard[ params[ 0 ] ] = blackboard[ params[ 0 ] ] + 1;
+            scene.sceneBlackboard[ params[ 0 ] ] = scene.sceneBlackboard[ params[ 0 ] ] + 1;
         }
         
     }

--- a/source/triggers/actionFactory.vwf.yaml
+++ b/source/triggers/actionFactory.vwf.yaml
@@ -38,6 +38,10 @@ properties:
     # arguments: variableName
     incrementBlackboardValue:
 
+    # clears the value at the specified blackboard variableName
+    # arguments: variableName
+    clearBlackboard:
+    
     # delays for a fixed time, and then plays one or more actions
     # arguments: delay, action(s)
     delay:

--- a/source/triggers/booleanFunctionFactory.js
+++ b/source/triggers/booleanFunctionFactory.js
@@ -568,13 +568,13 @@ this.clauseSet.readBlackboard = function( params, context ) {
         return undefined;
     }
 
-    var blackboard = context.sceneBlackboard;
-
-    var checkedValue = blackboard[ params[ 0 ] ];
+    var scene = self.find( "/" )[ 0 ];
+    
+    var checkedValue = scene.sceneBlackboard[ params[ 0 ] ];
 
     return function() {
 
-        if ( params[ 1 ] ){
+        if ( params[ 1 ] !== undefined ){
         var retVal = ( checkedValue !== undefined && checkedValue < params[ 1 ] );
         } else {
         var retVal = ( checkedValue !== undefined );  


### PR DESCRIPTION
By my reckoning (current understanding of triggers) this should work but isnt. @BrettASwift @kadst43 Could you point me to the fault in my logic here? Write "hasFailed" once a failure occurs, read it on the incomplete failure. Clear that value from the blackboard when the scenario restarts. The only thing I could think of is that the additionalConditions truth values are being evaluated on scenarioLoad so writing hasFailed to the blackboard once the first failure condition fires will do nothing since the readBlackboard call has already been evaluated to true?
