### PR TITLE
Fix for resetting the hasFailed blackboard entry

### DIFF
--- a/source/scenario/scenario1.vwf.yaml
+++ b/source/scenario/scenario1.vwf.yaml
@@ -139,6 +139,13 @@ properties:
       - stopSound:
         - musicStandardGameplay
 
+    resetFailure:
+      triggerCondition:
+      - onScenarioStart:
+      actions:
+      - clearBlackboard:
+        - hasFailed
+
     blinkBlocklyIcon:
       triggerCondition:
       - onScenarioStart:
@@ -169,8 +176,6 @@ properties:
         - environmentWind
       - writeToBlackboard:
         - musicStoryScreen
-      - clearBlackboard:
-        - hasFailed
 
     playStartingSounds:
       triggerCondition:


### PR DESCRIPTION
@kadst43 @AmbientOSX This is a fix for the "did not reach destination" failure only firing the once.
