### PR TITLE
Clear blockly on reset and switch scenario

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -823,6 +823,9 @@ function openScenarioMenu() {
 
 function restartGame() {
     var sceneID = vwf_view.kernel.application();
+    currentBlocklyNodeID = undefined;
+    clearBlockly();
+    vwf_view.kernel.setProperty( sceneID, "blockly_activeNodeID", undefined );
     vwf_view.kernel.setProperty( sceneID, "activeScenarioPath", "scenario1a" );
     closePauseMenu();
 }
@@ -853,6 +856,9 @@ function displayNextScenario() {
 function switchToDisplayedScenario() {
     var display = document.getElementById( "scenarioDisplay" );
     var displayedScenario = display.innerHTML;
+    currentBlocklyNodeID = undefined;
+    clearBlockly();
+    vwf_view.kernel.setProperty( sceneID, "blockly_activeNodeID", undefined );
     vwf_view.kernel.setProperty( vwf_view.kernel.application(), "activeScenarioPath", displayedScenario );
     closePauseMenu();
 }


### PR DESCRIPTION
When jumping scenarios or restarting the game using the pause menu, the blockly workspace is cleared, closed, and the active blockly tab is reset.

@kadst43 @AmbientOSX @ajiraffe 
