### PR TITLE
Allow video id of 0 to be played without reloading

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -204,7 +204,7 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
                 setRenderMode( RENDER_NONE );
                 var src = eventArgs[ 0 ];
                 var id = getVideoIdFromSrc( src );
-                if ( !id ) {
+                if ( isNaN( id ) || id < 0 || id >= videos.length ) {
                     id = loadVideo( src );
                 }
                 $( "#transitionScreen" ).fadeIn( function() {


### PR DESCRIPTION
@BrettASwift The intro cinematic was being reloaded after the main menu, since its id was 0. This should fix that. ( I only noticed because it would hang on a black screen until I paused/unpaused in the dev window. Looks like it happens for me whenever it needs to load a video on the spot. Not sure why that's the case, or if it's happening for anyone else. )
