### PR TITLE
Heading and sounds

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -390,6 +390,7 @@ vwf_view.satProperty = function( nodeID, propertyName, propertyValue ) {
 
     if ( nodeID === vwf_view.kernel.application() ) {
         if ( propertyName === "blockly_activeNodeID" ) {
+            Blockly.SOUNDS_ = {};
             selectBlocklyTab( propertyValue );
         }
     }
@@ -411,7 +412,6 @@ vwf_view.satProperty = function( nodeID, propertyName, propertyValue ) {
 }
 
 function setUpView() {
-    Blockly.SOUNDS_ = {};
     mainMenu = new MainMenu();
     hud = new HUD();
     createHUD();


### PR DESCRIPTION
- Removed Blockly interface sounds
- Remove heading initialization after Scenario 1H
  - 1A - 1H need to be set because turning to face the right direction is part of the scenario

@kadst43 @AmbientOSX
