### PR TITLE
Fix Camera Target Sticking

### DIFF
--- a/source/scenario/scenario1h.vwf.yaml
+++ b/source/scenario/scenario1h.vwf.yaml
@@ -175,14 +175,7 @@ children:
           actions:
           - panCamera:
             - /pickups/radio
-
-        panToRover_1h:
-          triggerCondition:
-          - delay:
-            - 5
-          actions:
-          - panCamera:
-            - /player/rover
+            - 3
 
         setCameraView:
           triggerCondition:

--- a/source/triggers/actionFactory.js
+++ b/source/triggers/actionFactory.js
@@ -313,18 +313,25 @@ this.actionSet.enableHelicam = function( params, context ) {
 }
 
 this.actionSet.panCamera = function( params, context ) {
-    if ( params && params.length > 1 ) {
-        self.logger.errorx( "panCamera", "This action takes one parameter: the " +
-                            "path of the node to pan towards.");
+    if ( params && params.length > 2 ) {
+        self.logger.errorx( "panCamera", "This action takes two parameters: the " +
+                            "path of the node to pan towards and an optional duration " +
+                            "for the camera to target that node before returning to " +
+                            "its original target.");
         return undefined;        
     }
 
     var targetPath = params[ 0 ];
+    var duration = params[ 1 ];
     var targetFollower = context.find( "//targetFollower" )[ 0 ];
 
     return function() {
+        var lastTargetPath = targetFollower.targetPath;
         targetFollower.camera.pointOfView = "thirdPerson";
         targetFollower.setTargetPath$( targetPath );
+        if ( !isNaN( duration ) ) {
+            targetFollower.future( duration ).setTargetPath$( lastTargetPath );
+        }
     }
 }
 

--- a/source/triggers/actionFactory.vwf.yaml
+++ b/source/triggers/actionFactory.vwf.yaml
@@ -66,7 +66,9 @@ properties:
     clearBlockly:
 
     # pans the camera to the node of the targetpath
-    # arguments: targetPath
+    # If duration is specified, the camera will pan back to its original
+    # target after the duration in seconds
+    # arguments: targetPath, (optional) duration
     panCamera:
 
     # shows text in either the status or alert areas


### PR DESCRIPTION
@kadst43 I changed the panCamera action to take an optional duration. If that duration is specified, the camera will pan back to its last target after the specified duration in seconds. No duration means that the switch is permanent.
