### PR TITLE
Highlight Objective Tile

### DIFF
--- a/index.vwf.yaml
+++ b/index.vwf.yaml
@@ -336,6 +336,24 @@ children:
         properties:
           groupVisible: false
           graphObjects: []
+      callOutTile:
+        extends: http://vwf.example.com/graphtool/graphplane.vwf
+        properties:
+          origin: [ 0, 0, 0 ]
+          normal: [ 0, 0, 1 ]
+          rotationAngle: 90
+          size: 1
+          color: [ 255, 255, 255 ]
+          opacity: 0.5
+          doubleSided: false
+          renderTop: true
+          visible: false
+        methods:
+          callOut:
+          blink:
+          stopBlink:
+        scripts:
+          - source: source/callouttile.js
   graph:
     extends: http://vwf.example.com/node3.vwf
     implements: http://vwf.example.com/blockly/controller.vwf

--- a/source/callouttile.js
+++ b/source/callouttile.js
@@ -1,0 +1,34 @@
+var camera;
+
+this.isBlinking = false;
+
+this.initialize = function() {
+    this.blink();
+}
+
+this.callOut = function( coords ) {
+    camera = this.find( "/player/targetFollower/camera" )[ 0 ];
+    coords[ 0 ] /= this.parent.graphScale;
+    coords[ 1 ] /= this.parent.graphScale;
+    coords[ 2 ] /= this.parent.graphScale;
+    this.origin = coords;
+    this.isBlinking = true;
+}
+
+this.blink = function() {
+    if ( this.isBlinking ) {
+        if ( camera.pointOfView === "topDown" ) {
+            this.visible = !this.visible;
+        } else {
+            this.visible = false;
+        }
+    } else {
+        this.visible = false;
+    }
+    this.future( 0.5 ).blink();
+}
+this.stopBlink = function() {
+    this.isBlinking = false;
+}
+
+//@ sourceURL=source/callouttile.js

--- a/source/scenario/globalScenarioTriggers.vwf.yaml
+++ b/source/scenario/globalScenarioTriggers.vwf.yaml
@@ -97,6 +97,7 @@ properties:
         - musicFailure
       - writeToBlackboard:
         - hasSucceeded
+      - cancelCallOut:
 
     recordKeepingOnFailure:
       triggerCondition:

--- a/source/scenario/scenario1e.vwf.yaml
+++ b/source/scenario/scenario1e.vwf.yaml
@@ -110,6 +110,13 @@ children:
           - playSound:
             - L1VO13_Rover
 
+        highlightEndTile:
+          triggerCondition:
+          - onScenarioStart:
+          actions:
+          - callOutObjective:
+            - [ 8, 6 ]
+
         playHint1_1e:
           triggerCondition:
           - delay:

--- a/source/scenario/scenario1g.vwf.yaml
+++ b/source/scenario/scenario1g.vwf.yaml
@@ -103,6 +103,13 @@ children:
           - playSound:
             - musicSuccessShort
 
+        highlightEndTile:
+          triggerCondition:
+          - onScenarioStart:
+          actions:
+          - callOutObjective:
+            - [ 8, 2 ]
+
         setCameraView:
           triggerCondition:
           - onBlocklyStarted:

--- a/source/scenario/scenario1h.vwf.yaml
+++ b/source/scenario/scenario1h.vwf.yaml
@@ -78,6 +78,13 @@ children:
           - writeToBlackboard:
             - Level1hStartSounds
 
+        highlightEndTile:
+          triggerCondition:
+          - onScenarioStart:
+          actions:
+          - callOutObjective:
+            - [ 8, 16 ]
+
         succeedOnSuccess_1h:
           triggerCondition:
           - onBlocklyStopped:
@@ -112,7 +119,7 @@ children:
             - showStatus:
               - "Click to continue!"
           - playVideo:
-            - "success_cinematic.mp4"          
+            - "success_cinematic.mp4"
 
         playHint1_1h:
           triggerCondition:

--- a/source/scenario/scenario2e.vwf.yaml
+++ b/source/scenario/scenario2e.vwf.yaml
@@ -93,6 +93,13 @@ children:
           - playSound:
             - L3VO1_Rover_S
 
+        highlightEndTile:
+          triggerCondition:
+          - onScenarioStart:
+          actions:
+          - callOutObjective:
+            - [ 13, 2 ]
+
         stopBlinkRoverTab_2e:
           triggerCondition:
           - or:

--- a/source/scenario/scenario2f.vwf.yaml
+++ b/source/scenario/scenario2f.vwf.yaml
@@ -95,6 +95,13 @@ children:
           - playSound:
             - L3VO2_Mission_S
 
+        highlightEndTile:
+          triggerCondition:
+          - onScenarioStart:
+          actions:
+          - callOutObjective:
+            - [ 7, 5 ]
+
         stopBlinkRoverTab_2f:
           triggerCondition:
           - or:

--- a/source/triggers/actionFactory.js
+++ b/source/triggers/actionFactory.js
@@ -443,6 +443,34 @@ this.actionSet.resetCameraView = function( params, context ) {
     }
 }
 
+this.actionSet.callOutObjective = function( params, context ) {
+    if ( params && params.length !== 1 ) {
+        self.logger.warnx( "callOutObjective", "This action takes one parameter: The " +
+                                               "coordinates of the tile to be called out." );
+    }
+
+    var callOutTile = context.gridTileGraph.callOutTile;
+    var grid = context[ context.activeScenarioPath ].grid;
+    var tileCoords = params[ 0 ];
+    var coords = grid.getWorldFromGrid( tileCoords[ 0 ], tileCoords[ 1 ] );
+
+    return function() {
+        callOutTile.callOut( coords );
+    }
+}
+
+this.actionSet.cancelCallOut = function( params, context ) {
+    if ( params && params.length > 0 ) {
+        self.logger.warnx( "cancelCallOut", "This action takes no parameters." );
+    }
+
+    var callOutTile = context.find( "/gridTileGraph/callOutTile" )[ 0 ];
+
+    return function() {
+        callOutTile.stopBlink();
+    }
+}
+
 function getScenario( context ) {
     if ( context.getCurrentScenario ){
         return context.getCurrentScenario();

--- a/source/triggers/actionFactory.vwf.yaml
+++ b/source/triggers/actionFactory.vwf.yaml
@@ -86,5 +86,13 @@ properties:
     # arguments: none
     resetCameraView:
 
+    # Adds a blinking tile to the objective grid space
+    # arguments: coordinates
+    callOutObjective:
+
+    # Removes callout tile
+    # arguments: none
+    cancelCallOut:
+
 scripts:
 - source: source/triggers/actionFactory.js


### PR DESCRIPTION
This adds the ability to highlight a tile. Used to highlight the objective tiles in scenarios where the end point is known. I didn't add it to scenario 3 for that reason. Tile currently displays separately from other grid tiles and works in top down mode (whether or not you have an overlay toggled.).

@kadst43 @AmbientOSX @ajiraffe 
