### PR TITLE
Improve Performance of HUD Draw

### DIFF
--- a/source/HUD.js
+++ b/source/HUD.js
@@ -56,8 +56,15 @@ HUD.prototype = {
         if ( this.visible ) {
             this.draw();
         }
-        this.quad.material.map.needsUpdate = true;
-        this.quad.material.needsUpdate = true;
+        var texture;
+        if ( this.quad.material && this.quad.material.map ) {
+            texture = this.quad.material.map;
+            this.quad.material.map = undefined;
+            texture.dispose();
+        }
+        texture = new THREE.Texture( this.canvas );
+        texture.needsUpdate = true;
+        this.quad.material = new THREE.MeshBasicMaterial( { map: texture, transparent: true } );
     },
 
     draw: function() {


### PR DESCRIPTION
It turns out that creating a new texture every frame is much, much faster than simply updating the old one. I have no idea why, but this change will decrease the render time by 50-70%.

@kadst43 @eric79 
