### PR TITLE
Display alert when page zoom is not 100%

### DIFF
--- a/index.vwf.css
+++ b/index.vwf.css
@@ -24,6 +24,15 @@ body {
     cursor: default;
 }
 
+#zoomAlert {
+    width: 300px;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+    background-color: rgba( 255, 255, 255, 0.8 );
+    color: rgb( 0, 0, 0 );
+}
+
 a {
     pointer-events: all;
 }

--- a/index.vwf.html
+++ b/index.vwf.html
@@ -35,6 +35,7 @@ limitations under the License.
 
 <!-- HTML -->
 <div id="version"></div>
+<div id="zoomAlert"></div>
 <div id="transitionScreen"></div>
 <div id="pauseScreen" style="display: none;">
   <div id="pauseMenu" class="pauseMenu">

--- a/source/index.js
+++ b/source/index.js
@@ -40,6 +40,7 @@ var cachedVolume = 1;
 var muted = false;
 var currentScenario;
 var scenarioList;
+var startingZoom;
 
 var renderTransition = true;
 var playingVideo = false;
@@ -482,6 +483,7 @@ function render( renderer, scene, camera ) {
                 renderer.autoClear = true;
                 loggerBox.style.display = "none";
                 mainMenu.setupRenderer( renderer );
+                checkPageZoom();
                 renderTransition = false;
             }
             mainMenu.render( renderer );
@@ -987,5 +989,37 @@ function setVolumeSliderPosition( volume ) {
     readoutPct = Math.round( readoutPct );
     readout.innerHTML = "Volume: " + readoutPct + "%";
 }
+
+function checkPageZoom() {
+    var zoom, alertDiv, alertStr;
+    // SVG detects the zoom level of the page. Blockly uses SVG, so we
+    //  can use it to detect the page zoom for us.
+    if ( Blockly && Blockly.svg ) {
+        zoom = Math.round( Blockly.svg.currentScale * 100 );
+        if ( startingZoom === undefined ) {
+            startingZoom = zoom;
+        }
+        alertDiv = document.getElementById( "zoomAlert" );
+        if ( zoom !== 100 ) {
+            alertStr = "Your browser zoom is at " + zoom + "%. Press Ctrl and";
+            alertStr += ( zoom > 100 ) ? " - " : " + ";
+            alertStr += "on your keyboard at the same time to change the zoom. ";
+            alertStr += "Please set the zoom to 100%"
+            alertStr += ( startingZoom === 100 ) ? "." : " and reload the page.";
+            alertDiv.style.display = "block";
+            alertDiv.style.fontSize = Math.round( 100 / zoom * 100 ) + "%";
+            alertDiv.style.width = Math.round( 100 / zoom * 300 ) + "px";
+        } else if ( startingZoom !== 100 ) {
+            alertStr = "Zoom set to 100%. Please reload the page.";
+            alertDiv.style.display = "block";
+        } else {
+            alertStr = "";
+            alertDiv.style.display = "none";
+        }
+        alertDiv.innerHTML = alertStr;
+    }
+}
+
+window.addEventListener( "resize", checkPageZoom );
 
 //@ sourceURL=source/index.js


### PR DESCRIPTION
@kadst43 @eric79 

This detects the browser zoom level and alerts the user as well as instructs them on how to fix it. If the zoom level is not 100% at startup, then a reload is required to fix it. Otherwise, the alert will disappear when the page zoom is set to 100%. The alert also scales inversely with the page zoom so that the size on screen remains constant (no, this can't easily be done to negate page zoom in general). This works in Chrome, at least on my machine, so give it a test to be sure. I haven't tested other browsers.
