### PR TITLE
Fix callout tile placement on failure

### DIFF
--- a/source/triggers/actionFactory.js
+++ b/source/triggers/actionFactory.js
@@ -498,9 +498,9 @@ this.actionSet.callOutObjective = function( params, context ) {
     var callOutTile = context.gridTileGraph.callOutTile;
     var grid = context[ context.activeScenarioPath ].grid;
     var tileCoords = params[ 0 ];
-    var coords = grid.getWorldFromGrid( tileCoords[ 0 ], tileCoords[ 1 ] );
 
     return function() {
+        var coords = grid.getWorldFromGrid( tileCoords[ 0 ], tileCoords[ 1 ] );
         callOutTile.callOut( coords );
     }
 }


### PR DESCRIPTION
This fixes the issue of the callout tile (blinking objective tile) not being placed properly after failure.

@eric79 @kadst43 
