### PR TITLE
Add config parameter to preserve script closures

### DIFF
--- a/index.vwf.config.yaml
+++ b/index.vwf.config.yaml
@@ -24,4 +24,5 @@ view:
   vwf/view/blockly: { "blocklyPath": './source/blockly/', "toolbox": 'toolbox' }
   vwf/view/sound:
   # vwf/view/editor:
-  
+configuration:
+  preserve-script-closures: true


### PR DESCRIPTION
This commit will keep mars-game working when the event-handler replication branch is merged to development (but keeps us from taking advantage of event handler replication).  We will eventually need to eliminate our use of closure variables in methods and event handlers so that we can remove this config parameter and take advantage of event handler replication.

Once merged, we should probably merge `mars-game-staging` to `master` so the app running on `development.virtual.wf` will continue working when the event-handler branch is merged to `development`.

@BrettASwift @kadst43 @AmbientOSX would you mind reviewing?
