### PR TITLE
Enable blockly nodes

### DIFF
--- a/index.vwf.yaml
+++ b/index.vwf.yaml
@@ -69,6 +69,8 @@ methods:
   unpauseGame:
   resetHUDState:
   selectBlocklyNode:
+  enableBlocklyNodes:
+  disableBlocklyNodes:
 events:
   gameStarted:
   scenarioReset:
@@ -86,7 +88,7 @@ events:
   toggledGraph:
   toggledTiles:
   resetRoverSensors:
-  enableBlocklyTab:
+  enableBlocklyTabs:
   clearBlocklyTabs:
   videoPlayed:
   progressFound:

--- a/source/hud/roverSelector.js
+++ b/source/hud/roverSelector.js
@@ -72,7 +72,6 @@ this.addRoverIcon = function( node, src, enabled ) {
     images[ nodeID ] = src;
     this.images = images;
     this.rovers.push( {
-        "node": node,
         "id": nodeID,
         "enabled": enabled,
         "active": false,

--- a/source/hud/roverSelector.js
+++ b/source/hud/roverSelector.js
@@ -17,7 +17,7 @@ this.draw = function( context, position ) {
     for ( var i = 0; i < this.rovers.length; i++ ) {
         if ( this.rovers[ i ].enabled ) {
             rover = this.rovers[ i ];
-            icon = this[ rover.name ];
+            icon = this[ rover.id ];
             if ( icon ) {
                 posx = position.x + rover.position.x;
                 posy = position.y + rover.position.y;
@@ -43,7 +43,7 @@ this.onClick = function( elementPos ) {
         for ( i = 0, enabledIndex = 0; i < this.rovers.length; i++ ) {
             if ( this.rovers[ i ].enabled ) {
                 if ( iconIndex === enabledIndex ) {
-                    selectedRover = this.rovers[ i ].name;
+                    selectedRover = this.rovers[ i ].id;
                     break;
                 }
                 enabledIndex++;
@@ -54,11 +54,11 @@ this.onClick = function( elementPos ) {
     }
 }
 
-this.selectRover = function( name ) {
+this.selectRover = function( nodeID ) {
     var rover;
     for ( var i = 0; i < this.rovers.length; i++ ) {
         rover = this.rovers[ i ];
-        if ( rover.name === name ) {
+        if ( rover.id === nodeID ) {
             rover.active = true;
         } else {
             rover.active = false;
@@ -66,13 +66,14 @@ this.selectRover = function( name ) {
     }
 }
 
-this.addRoverIcon = function( name, node, src, enabled ) {
+this.addRoverIcon = function( node, src, enabled ) {
+    var nodeID = node.id;
     var images = this.images;
-    images[ name ] = src;
+    images[ nodeID ] = src;
     this.images = images;
     this.rovers.push( {
         "node": node,
-        "name": name,
+        "id": nodeID,
         "enabled": enabled,
         "active": false,
         "position": {
@@ -83,20 +84,14 @@ this.addRoverIcon = function( name, node, src, enabled ) {
     this.updateIconOrder();
 }
 
-this.showRoverIcon = function( name ) {
+// Pass a boolean to show (true) or hide (false) icons
+// Pass in an array of nodeIDs to display specific icons
+// Pass nothing in to display all icons
+this.showRoverIcons = function( show, nodeIDs ) {
     for ( var i = 0; i < this.rovers.length; i++ ) {
-        if ( this.rovers[ i ].name === name ) {
-            this.rovers[ i ].enabled = true;
-            break;
-        }
-    }
-    this.updateIconOrder();
-}
-
-this.hideRoverIcon = function( name ) {
-    for ( var i = 0; i < this.rovers.length; i++ ) {
-        if ( this.rovers[ i ].name === name ) {
-            this.rovers[ i ].enabled = false;
+        var rover = this.rovers[ i ];
+        if ( !nodeIDs || nodeIDs.indexOf( rover.id ) !== -1 ) {
+            rover.enabled = show;
             break;
         }
     }

--- a/source/hud/roverSelector.vwf.yaml
+++ b/source/hud/roverSelector.vwf.yaml
@@ -38,8 +38,7 @@ properties:
 methods:
   draw:
   addRoverIcon:
-  showRoverIcon:
-  hideRoverIcon:
+  showRoverIcons:
   selectRover:
 events:
   onClick:

--- a/source/scenario/scenario1a.vwf.yaml
+++ b/source/scenario/scenario1a.vwf.yaml
@@ -76,7 +76,7 @@ properties:
   - addToGrid:
     - radio
     - [ 8, 16 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
   - loadToolbox:
     - rover

--- a/source/scenario/scenario1b.vwf.yaml
+++ b/source/scenario/scenario1b.vwf.yaml
@@ -69,7 +69,7 @@ properties:
     - radio
     - [ 8, 16 ]
 
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
   - loadToolbox:
     - rover

--- a/source/scenario/scenario1c.vwf.yaml
+++ b/source/scenario/scenario1c.vwf.yaml
@@ -68,7 +68,7 @@ properties:
   - addToGrid:
     - radio
     - [ 8, 16 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
   - loadToolbox:
     - rover

--- a/source/scenario/scenario1d.vwf.yaml
+++ b/source/scenario/scenario1d.vwf.yaml
@@ -65,7 +65,7 @@ properties:
   - addToGrid:
     - radio
     - [ 8, 16 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
   - loadToolbox:
     - rover

--- a/source/scenario/scenario1e.vwf.yaml
+++ b/source/scenario/scenario1e.vwf.yaml
@@ -65,7 +65,7 @@ properties:
   - addToGrid:
     - radio
     - [ 8, 16 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
   - loadToolbox:
     - rover

--- a/source/scenario/scenario1f.vwf.yaml
+++ b/source/scenario/scenario1f.vwf.yaml
@@ -57,7 +57,7 @@ properties:
   - addToGrid:
     - radio
     - [ 8, 16 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
   - loadToolbox:
     - rover

--- a/source/scenario/scenario1g.vwf.yaml
+++ b/source/scenario/scenario1g.vwf.yaml
@@ -61,7 +61,7 @@ properties:
   - addToGrid:
     - radio
     - [ 8, 16 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
   - loadToolbox:
     - rover

--- a/source/scenario/scenario1h.vwf.yaml
+++ b/source/scenario/scenario1h.vwf.yaml
@@ -62,7 +62,7 @@ properties:
   - addToGrid:
     - radio
     - [ 8, 16 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
   - loadToolbox:
     - rover

--- a/source/scenario/scenario2a.vwf.yaml
+++ b/source/scenario/scenario2a.vwf.yaml
@@ -54,7 +54,7 @@ properties:
   - addToGrid:
     - blocklyGraph
     - [ 15, 1 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario2b.vwf.yaml
+++ b/source/scenario/scenario2b.vwf.yaml
@@ -50,7 +50,7 @@ properties:
   - addToGrid:
     - blocklyGraph
     - [ 15, 1 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario2c.vwf.yaml
+++ b/source/scenario/scenario2c.vwf.yaml
@@ -50,7 +50,7 @@ properties:
   - addToGrid:
     - blocklyGraph
     - [ 15, 1 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario2d.vwf.yaml
+++ b/source/scenario/scenario2d.vwf.yaml
@@ -50,7 +50,7 @@ properties:
   - addToGrid:
     - blocklyGraph
     - [ 15, 1 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario2e.vwf.yaml
+++ b/source/scenario/scenario2e.vwf.yaml
@@ -50,7 +50,7 @@ properties:
   - addToGrid:
     - blocklyGraph
     - [ 15, 1 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario2f.vwf.yaml
+++ b/source/scenario/scenario2f.vwf.yaml
@@ -50,7 +50,7 @@ properties:
   - addToGrid:
     - blocklyGraph
     - [ 13, 2 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario3a.vwf.yaml
+++ b/source/scenario/scenario3a.vwf.yaml
@@ -55,7 +55,7 @@ properties:
   - addToGrid:
     - supplies_1
     - [ 7, 15 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario3b.vwf.yaml
+++ b/source/scenario/scenario3b.vwf.yaml
@@ -56,7 +56,7 @@ properties:
   - removeFromGrid:
     - supplies_1
     - [ 37, 15 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario3c.vwf.yaml
+++ b/source/scenario/scenario3c.vwf.yaml
@@ -56,7 +56,7 @@ properties:
   - addToGrid:
     - supplies_2
     - [ 12, 10 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario3d.vwf.yaml
+++ b/source/scenario/scenario3d.vwf.yaml
@@ -56,7 +56,7 @@ properties:
   - removeFromGrid:
     - supplies_2
     - [ 12, 10 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario3e.vwf.yaml
+++ b/source/scenario/scenario3e.vwf.yaml
@@ -53,7 +53,7 @@ properties:
   - addToGrid:
     - minirover
     - [ 24, 39 ]
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - graph
   - loadToolbox:

--- a/source/scenario/scenario_dummy.vwf.yaml
+++ b/source/scenario/scenario_dummy.vwf.yaml
@@ -95,7 +95,7 @@ properties:
     - blocklyGraph
     - [ 37, 15 ]
 
-  - enableBlocklyTabs:
+  - enableBlocklyNodes:
     - rover
     - rover2
     - rover3

--- a/source/scene.js
+++ b/source/scene.js
@@ -63,7 +63,7 @@ this.setApplicationState = function( state ) {
         case "playing":
             this.mainMenu.visible = false;
             this.soundManager.stopSoundGroup( "music" );
-            this.selectBlocklyNode( "rover" );
+            this.selectBlocklyNode( this.player.rover.id );
             // TODO: Consolidate game nodes
             this.environment.visible = true;
             this.player.visible = true;
@@ -269,17 +269,14 @@ this.setUpRoverListeners = function() {
     // rover.findAndSetCurrentGrid( this.activeScenarioPath );
     // TODO: Find a more appropriate location for the following
     this.hud.roverSelector.future( 0 ).addRoverIcon(
-        "rover",
         this.player.rover,
         "assets/images/hud/main_rover_icon.png",
         false );
     this.hud.roverSelector.future( 0 ).addRoverIcon(
-        "rover2",
         this.player.rover2,
         "assets/images/hud/scout_rover_icon.png",
         false );
     this.hud.roverSelector.future( 0 ).addRoverIcon(
-        "rover3",
         this.player.rover3,
         "assets/images/hud/main_rover_icon.png",
         false );
@@ -395,35 +392,32 @@ this.unpauseGame = function() {
     this.unpaused();
 }
 
-this.selectBlocklyNode = function( nodeName ) {
-    var node = this.find( "//" + nodeName )[ 0 ];
-    if ( this.blockly_activeNodeID !== node.id ) {
-        this.blockly_activeNodeID = node.id;
-    }
-    if ( node.defaultMount && this.gameCam.target !== node ) {
-        this.gameCam.setCameraTarget( node );
-        this.hud.roverSelector.selectRover( nodeName );
-    } else if ( node === this.graph ) {
-        this.gameCam.setCameraMount( "topDown" );
-    }
-}
-
-// TODO: Do this in a better place and/or rewrite
-//   enableBlocklyTabs action as enableBlocklyNodes
-this.clearBlocklyTabs = function() {
-    var rovers = this.hud.roverSelector.rovers;
-    for ( var i = 0; i < rovers.length; i++ ) {
-        this.hud.roverSelector.hideRoverIcon( rovers[ i ].name );
-    }
-}
-
-this.enableBlocklyTab = function( nodeID ) {
-    var rovers = this.hud.roverSelector.rovers;
-    for ( var i = 0; i < rovers.length; i++ ) {
-        if ( nodeID === rovers[ i ].node.id ) {
-            this.hud.roverSelector.showRoverIcon( rovers[ i ].name );
+this.selectBlocklyNode = function( nodeID ) {
+    var node = this.findByID( this, nodeID );
+    if ( node ) {
+        if ( this.blockly_activeNodeID !== nodeID ) {
+            this.blockly_activeNodeID = nodeID;
         }
+        if ( node.defaultMount && this.gameCam.target !== node ) {
+            this.gameCam.setCameraTarget( node );
+            this.hud.roverSelector.selectRover( nodeID );
+        } else if ( node === this.graph ) {
+            this.gameCam.setCameraMount( "topDown" );
+        }
+    } else {
+        this.logger.errorx( "selectBlocklyNode", "Could not find " +
+            "node with ID: " + nodeID );
     }
+}
+
+this.enableBlocklyNodes = function( nodes ) {
+    this.enableBlocklyTabs( nodes );
+    this.hud.roverSelector.showRoverIcons( true, nodes )
+}
+
+this.disableBlocklyNodes = function( nodes ) {
+    this.clearBlocklyTabs( nodes );
+    this.hud.roverSelector.showRoverIcons( false, nodes );
 }
 
 //@ sourceURL=source/scene.js

--- a/source/triggers/actions/action_enableBlocklyNodes.js
+++ b/source/triggers/actions/action_enableBlocklyNodes.js
@@ -20,25 +20,27 @@ this.onGenerated = function( params, generator, payload ) {
     if ( !params || ( params.length < 1 ) ) {
         this.logger.errorx( "onGenerated", 
                             "This action takes one or more arguments: " +
-                            "the name(s) of the tab(s) to be enabled." );
+                            "the name(s) of the node(s) to be enabled." );
         return false;
     }
 
-    this.tabNames = params;
+    this.nodeNames = params;
     return true;
 }
 
 this.executeAction = function() {
-    this.scene.clearBlocklyTabs();
-    for ( var i = 0; i < this.tabNames.length; i++ ) {
-        var object = this.findInScene( this.tabNames[ i ] );
+    this.scene.disableBlocklyNodes();
+    var nodeIDs = [];
+    for ( var i = 0; i < this.nodeNames.length; i++ ) {
+        var object = this.findInScene( this.nodeNames[ i ] );
         if ( object ) {
-            this.scene.enableBlocklyTab( object.id );
+            nodeIDs.push( object.id );
         } else {
-            this.logger.warnx( "executeAction", "Tab '" + this.tabNames[ i ] + 
-                                                "' not found!" );
+            this.logger.warnx( "executeAction", "Blockly node '" +
+                                this.nodeNames[ i ] + "' not found!" );
         }
     }
+    this.scene.enableBlocklyNodes( nodeIDs );
 }
 
-//@ sourceURL=source/triggers/actions/action_enableBlocklyTabs.js
+//@ sourceURL=source/triggers/actions/action_enableBlocklyNodes.js

--- a/source/triggers/actions/action_enableBlocklyNodes.vwf.yaml
+++ b/source/triggers/actions/action_enableBlocklyNodes.vwf.yaml
@@ -16,7 +16,7 @@
 extends: actionProto.vwf
 
 properties:
-  tabNames:
+  nodeNames:
 
 scripts:
-- source: action_enableBlocklyTabs.js
+- source: action_enableBlocklyNodes.js

--- a/source/triggers/generators/generator_Action.vwf.yaml
+++ b/source/triggers/generators/generator_Action.vwf.yaml
@@ -119,7 +119,7 @@ properties:
     addToInventory: "source/triggers/actions/action_addToInventory.vwf"
     addToGrid: "source/triggers/actions/action_addToGrid.vwf"
     removeFromGrid: "source/triggers/actions/action_removeFromGrid.vwf"
-    enableBlocklyTabs: "source/triggers/actions/action_enableBlocklyTabs.vwf"
+    enableBlocklyNodes: "source/triggers/actions/action_enableBlocklyNodes.vwf"
     loadToolbox: "source/triggers/actions/action_loadToolbox.vwf"
 
 scripts:

--- a/source/view/index.js
+++ b/source/view/index.js
@@ -171,7 +171,14 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
                 break;
 
             case "clearBlocklyTabs":
-                clearBlocklyTabs();
+                var tabs = eventArgs[ 0 ];
+                if ( tabs !== undefined ) {
+                    for ( var i = 0; i < tabs.length; i++ ) {
+                        removeBlocklyTab( tabs[ i ] );
+                    }
+                } else {
+                    clearBlocklyTabs( eventArgs[ 0 ] );
+                }
                 break;
 
             case "toggledTiles":
@@ -182,8 +189,11 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
                 graphIsVisible = eventArgs[ 0 ];
                 break;
             
-            case "enableBlocklyTab":
-                addBlocklyTab( eventArgs[ 0 ], eventArgs[ 1 ] );
+            case "enableBlocklyTabs":
+                var tabs = eventArgs[ 0 ];
+                for ( var i = 0; i < tabs.length; i++ ) {
+                    addBlocklyTab( tabs[ i ] );
+                }
                 break;
 
             case "videoPlayed":
@@ -279,7 +289,6 @@ vwf_view.initializedNode = function( nodeID, childID, childExtendsID, childImple
         node.tab.id = childID;
         node.tab.className = "blocklyTab";
         node.tab.onclick = setActiveBlocklyTab;
-        node.tab.vwfNodeName = childName;
         node.tab.innerHTML = childName;
     }
 }
@@ -530,7 +539,7 @@ function runBlockly() {
 
 function setActiveBlocklyTab() {
     if ( currentBlocklyNodeID !== this.id ) {
-        vwf_view.kernel.callMethod( appID, "selectBlocklyNode", [ this.vwfNodeName ] );
+        vwf_view.kernel.callMethod( appID, "selectBlocklyNode", [ this.id ] );
         if ( blocklyGraphID && blocklyGraphID === this.id ) {
             hideBlocklyIndicator();
         } else {


### PR DESCRIPTION
@kadst43 @AmbientOSX @nmarshak1337 

- Changed `enableBlocklyTabs` to `enableBlocklyNodes` which enables the tabs and sets up the rover HUD icons.
- Improved enable/disable tabs by firing one event and passing an array of ids to the view, rather than firing an event for each tab.
- Improved the rover selector code by using only node IDs and removing rover node references.

Requires: https://github.com/virtual-world-framework/vwf/pull/482