### PR TITLE
Fix Grid Collision

### DIFF
--- a/index.vwf.yaml
+++ b/index.vwf.yaml
@@ -658,7 +658,8 @@ children:
     includes: source/scenario/scenario3f.vwf
   blocklyGraph:
     extends: http://vwf.example.com/graphtool/graph.vwf
-    implements: "source/griddable.vwf"
+    implements: 
+      - source/griddable.vwf
     properties:
       graphScale: 3
       gridInterval: 1
@@ -672,6 +673,7 @@ children:
       axisOpacity: 1
       gridOpacity: 0.75
       renderTop: true
+      isCollidable: false
     children:
       blocklyLine:
         extends: http://vwf.example.com/graphtool/graphlinefunction.vwf

--- a/source/grid.vwf.yaml
+++ b/source/grid.vwf.yaml
@@ -14,6 +14,8 @@
 
 ---
 extends: http://vwf.example.com/node.vwf
+implements:
+  - http://vwf.example.com/sceneGetter.vwf
 properties:
   tiles: []
   boundaryValues: []
@@ -23,25 +25,25 @@ properties:
   minY: 0
   maxX: 32
   maxY: 32
-
 methods:
+  setBoundaryValues:
+  clearGrid:
+  getTileFromGrid:
+  getTileFromWorld:
+  getGridFromWorld:
+  getWorldFromGrid:
+  validCoord:
+  getObjectsAtCoord:
   addToGrid:
   addToGridFromCoord:
   addToGridFromWorld:
   removeFromGrid:
   moveObjectOnGrid:
-  checkCoord:
-  validCoord:
-  isOccupied:
-  getTileFromGrid:
-  getTileFromWorld:
-  getWorldFromGrid:
-  getGridFromWorld:
-  setBoundaryValues:
-  clearGrid:
-  hasInventoriable:
-  hasCollidable:
+  setHeightFromTerrain:
+  getInventoriables:
+  getCollidables:
   getEnergy:
-
+  checkCollision:
+  createTile:
 scripts:
 - source: grid.js

--- a/source/rover.js
+++ b/source/rover.js
@@ -50,8 +50,8 @@ this.moveForward = function() {
         } else {
 
             //Otherwise, check if the space is occupied
-            if ( this.currentGrid.getCollidables( proposedNewGridSquare ).length === 0 ){
-                this.currentGrid.moveObjectOnGrid( this, this.currentGridSquare, proposedNewGridSquare );
+            if ( !this.currentGrid.checkCollision( proposedNewGridSquare ) ){
+                this.currentGrid.moveObjectOnGrid( this.id, this.currentGridSquare, proposedNewGridSquare );
                 this.currentGridSquare = proposedNewGridSquare;
                 var displacement = [ dirVector[ 0 ] * this.currentGrid.gridSquareLength, 
                                      dirVector[ 1 ] * this.currentGrid.gridSquareLength, 0 ];
@@ -69,7 +69,7 @@ this.moveForward = function() {
                 if ( inventoriableObjects ){
                     for ( var i = 0; i < inventoriableObjects.length; i++ ) {
                         this.currentGrid.removeFromGrid( inventoriableObjects[ i ], proposedNewGridSquare );
-                        this.cargo.add( inventoriableObjects[ i ].id );
+                        this.cargo.add( inventoriableObjects[ i ] );
                     }
                 }
                 this.moved();

--- a/source/triggers/actions/action_removeFromGrid.js
+++ b/source/triggers/actions/action_removeFromGrid.js
@@ -37,7 +37,7 @@ this.executeAction = function() {
     this.assert( object, "Object not found!" );
     this.assert( scenario, "Scenario not found!" );
     // TODO: Check that the coordinate is valid?
-    object && scenario && scenario.grid.removeFromGrid( object, 
+    object && scenario && scenario.grid.removeFromGrid( object.id, 
                                                         this.gridCoord );
 }
 


### PR DESCRIPTION
@kadst43 @AmbientOSX @nmarshak1337 
- Fixed the bug with rovers not updating their locations on the grid properly, causing collisions where the rover used to be.
- Modified some grid methods to use node IDs instead of nodes.
  - Tiles now store node IDs rather than node references in their objects arrays.
  - This eliminates most of the `valueJSFromKernel` warnings.