### PR TITLE
Remove VWF calls from the inner loop of trigger group checks.  

### DIFF
--- a/source/triggers/groups/triggerGroup.js
+++ b/source/triggers/groups/triggerGroup.js
@@ -39,12 +39,17 @@ this.checkTriggers$ = function() {
     this.isEvaluating$ = true;
 
     // First, check if each trigger is ready to fire.
+    var triggers = this.triggers$;
+    var numTriggers = triggers.length;
     var haveTriggerToFire = false;
-    for ( var i = 0; i < this.triggers$.length; ++i ) {
-        var trigger = this.triggers$[ i ];
-        this.canFire$[ i ] = trigger.check();
-        haveTriggerToFire = haveTriggerToFire || this.canFire$[ i ];
+    var canFire = this.canFire$;
+    for ( var i = 0; i < numTriggers; ++i ) {
+        canFire[ i ] = triggers[ i ].check();
+        haveTriggerToFire = haveTriggerToFire || canFire[ i ];
     }
+
+    this.canFire$ = canFire;
+    this.triggers$ = triggers;
 
     // done evaluating (for now)
     this.isEvaluating$ = false;
@@ -57,7 +62,7 @@ this.checkTriggers$ = function() {
     //  impossible - especially with a low frame rate.  In order to address 
     //  this, do another check after a future(0).
     if ( haveTriggerToFire ) {
-        this.future( 0.01 ).checkTriggersCallback$();
+        this.future( 0 ).checkTriggersCallback$();
     } else if ( this.isChecking ) {
         // schedule the next check
         this.future( this.checkFrequency$ ).checkTriggers$();

--- a/source/triggers/groups/triggerGroup.js
+++ b/source/triggers/groups/triggerGroup.js
@@ -40,16 +40,15 @@ this.checkTriggers$ = function() {
 
     // First, check if each trigger is ready to fire.
     var triggers = this.triggers$;
-    var numTriggers = triggers.length;
-    var haveTriggerToFire = false;
     var canFire = this.canFire$;
-    for ( var i = 0; i < numTriggers; ++i ) {
+
+    var haveTriggerToFire = false;
+    for ( var i = 0; i < triggers.length; ++i ) {
         canFire[ i ] = triggers[ i ].check();
         haveTriggerToFire = haveTriggerToFire || canFire[ i ];
     }
 
     this.canFire$ = canFire;
-    this.triggers$ = triggers;
 
     // done evaluating (for now)
     this.isEvaluating$ = false;


### PR DESCRIPTION
Saves maybe 2-3% of execution time, so not huge.

@BrettASwift 