### PR TITLE
Fix Tile Blinking

### DIFF
--- a/source/view/index.js
+++ b/source/view/index.js
@@ -445,8 +445,10 @@ vwf_view.satProperty = function( nodeID, propertyName, propertyValue ) {
             if ( hud ) {
                 var selector = hud.elements.cameraSelector;
                 var pov = hud.elements[ "camera_" + propertyValue ];
-                selector.activeMode.icon = pov.icon;
-                selector.activeMode.type = pov.mode;
+                if ( pov ) {
+                    selector.activeMode.icon = pov.icon;
+                    selector.activeMode.type = pov.mode;
+                }
             }
         }
     }


### PR DESCRIPTION
@kadst43 @AmbientOSX @nmarshak1337 

This is one of those really odd bugs that stresses the importance of making sure there are no errors in the console. The tiles not blinking were caused by an error being generated when `pov` was undefined in the `mountName` `satProperty` handler. This caused `mountName` to no longer be able to be set in the model, so it was stuck with a value of `default` after the camera pans to the radio. The tile blinking checks to make sure that the value of `mountName` is `topDown` or else it does not blink.