### PR TITLE
Camera Changes

### DIFF
--- a/index.vwf.yaml
+++ b/index.vwf.yaml
@@ -327,6 +327,7 @@ children:
               navmode: thirdPerson
               cameraPose: [ 16, 0, -15 ]
               cameraSpeed: 0
+              usePoseFromCamera: true
           topDown:
             extends: source/cameraMount.vwf
             properties:
@@ -428,6 +429,7 @@ children:
               navmode: thirdPerson
               cameraPose: [ 16, 0, -15 ]
               cameraSpeed: 0
+              usePoseFromCamera: true
           topDown:
             extends: source/cameraMount.vwf
             properties:
@@ -541,6 +543,7 @@ children:
               navmode: thirdPerson
               cameraPose: [ 16, 0, -15 ]
               cameraSpeed: 0
+              usePoseFromCamera: true
           topDown:
             extends: source/cameraMount.vwf
             properties:

--- a/source/callouttile.js
+++ b/source/callouttile.js
@@ -29,7 +29,7 @@ this.callOut = function( coords ) {
 this.blink = function() {
     var camera = this.find( "/gameCam" )[ 0 ];
     if ( this.isBlinking ) {
-        if ( camera.mountName === "topDown" ) {
+        if ( camera.mount.name === "topDown" ) {
             this.visible = !this.visible;
         } else {
             this.visible = false;

--- a/source/cameraMount.vwf.yaml
+++ b/source/cameraMount.vwf.yaml
@@ -27,8 +27,8 @@ properties:
   worldOffset: [ 0, 0, 0 ]
   useTargetRotation: false
   cameraLock: true
+  usePoseFromCamera: false
 methods:
   mountCamera:
-events:
 scripts:
   - source: cameraMount.js

--- a/source/cameraTarget.js
+++ b/source/cameraTarget.js
@@ -13,44 +13,44 @@
 // limitations under the License.
 
 this.getMount = function( mountName ) {
-	var mount;
-	if ( mountName ) {
-		mount = this[ mountName ];
-		if ( !mount ) {
-			this.logger.errorx( "getMount", this.name + "." + mountName + " could not be found!" );
-			return undefined;
-		} else if ( !mount.mountCamera ) {
-			this.logger.errorx( "getMount", this.name + "." + mountName + " is not a cameraMount!" );
-			return undefined;
-		}
-	} else {
-		mount = this.defaultMount;
-	}
-	return mount;
+    var mount;
+    if ( mountName ) {
+        mount = this[ mountName ];
+        if ( !mount ) {
+            this.logger.errorx( "getMount", this.name + "." + mountName + " could not be found!" );
+            return undefined;
+        } else if ( !mount.mountCamera ) {
+            this.logger.errorx( "getMount", this.name + "." + mountName + " is not a cameraMount!" );
+            return undefined;
+        }
+    } else {
+        mount = this.defaultMount;
+    }
+    return mount;
 }
 
 this.setDefaultMount = function( mountName ) {
-	var mount;
-	if ( mountName ) {
-		mount = this[ mountName ];
-		if ( !mount ) {
-			this.logger.errorx( "setDefaultMount", this.name + "." + mountName + " could not be found!" );
-		} else if ( !mount.mountCamera ) {
-			this.logger.errorx( "setDefaultMount", this.name + "." + mountName + " is not a cameraMount!" );
-		}
-	} else {
-		this.logger.errorx( "setDefaultMount", "No mount name found!" );
-	}
-	this.defaultMount = mount;
+    var mount;
+    if ( mountName ) {
+        mount = this[ mountName ];
+        if ( !mount ) {
+            this.logger.errorx( "setDefaultMount", this.name + "." + mountName + " could not be found!" );
+        } else if ( !mount.mountCamera ) {
+            this.logger.errorx( "setDefaultMount", this.name + "." + mountName + " is not a cameraMount!" );
+        }
+    } else {
+        this.logger.errorx( "setDefaultMount", "No mount name found!" );
+    }
+    this.defaultMount = mount;
 }
 
 this.hasMount = function( mountName ) {
-	var mount = this[ mountName ];
-	if ( mount && mount.mountCamera ) {
-		return true;
-	} else {
-		return false;
-	}
+    var mount = this[ mountName ];
+    if ( mount && mount.mountCamera ) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 //@ sourceURL=source/cameraTarget.js

--- a/source/cinematicCameraController.js
+++ b/source/cinematicCameraController.js
@@ -41,7 +41,7 @@ this.getCameraPosition = function() {
 
 this.copyCameraState = function() {
     this.cameraState.target = this.scene.gameCam.target;
-    this.cameraState.mountName = this.scene.gameCam.mountName;
+    this.cameraState.mountName = this.scene.gameCam.mount.name;
 }
 
 this.restoreCameraState = function() {

--- a/source/gameCamera.js
+++ b/source/gameCamera.js
@@ -110,19 +110,6 @@ this.convertPoseToTransform = function( pose ) {
     ];
 }
 
-this.getPoseFromTransform = function() {
-    var transform = this.camera.transform;
-    var radiansToDegrees = 180 / Math.PI;
-    var radius, yaw, pitch;
-    var cosPitch, sinYaw;
-    cosPitch = transform[ 10 ];
-    sinYaw = transform[ 1 ];
-    radius = transform[ 12 ] / cosPitch / sinYaw;
-    yaw = Math.asin( sinYaw ) * radiansToDegrees;
-    pitch = Math.acos( cosPitch ) * radiansToDegrees;
-    return [ radius, yaw, pitch ];
-}
-
 this.mounted = function( mount ) {
     this.mount = mount;
 }

--- a/source/gameCamera.js
+++ b/source/gameCamera.js
@@ -26,11 +26,15 @@ this.setCameraTarget = function( node, mountName ) {
 }
 
 this.setCameraMount = function( mountName ) {
-    var mount;
+    var mount, cameraPose;
     mount = this.target.getMount( mountName );
     if ( !mount ) {
         this.logger.errorx( "setCameraMount", "No camera mount could be found!" );
     } else {
+        if ( this.mount && this.mount.usePoseFromCamera ) {
+            cameraPose = this.getPoseFromTransform();
+            this.mount.cameraPose = cameraPose;
+        }
         mount.mountCamera( this );
     }
 }
@@ -106,8 +110,21 @@ this.convertPoseToTransform = function( pose ) {
     ];
 }
 
+this.getPoseFromTransform = function() {
+    var transform = this.camera.transform;
+    var radiansToDegrees = 180 / Math.PI;
+    var radius, yaw, pitch;
+    var cosPitch, sinYaw;
+    cosPitch = transform[ 10 ];
+    sinYaw = transform[ 1 ];
+    radius = transform[ 12 ] / cosPitch / sinYaw;
+    yaw = Math.asin( sinYaw ) * radiansToDegrees;
+    pitch = Math.acos( cosPitch ) * radiansToDegrees;
+    return [ radius, yaw, pitch ];
+}
+
 this.mounted = function( mount ) {
-    this.mountName = mount.name;
+    this.mount = mount;
 }
 
 this.getPoseFromTransform = function() {

--- a/source/gameCamera.js
+++ b/source/gameCamera.js
@@ -53,6 +53,8 @@ this.followTarget = function( transform ) {
         transform[ 13 ],
         transform[ 14 ]
     ];
+    var cameraPose = this.getPoseFromTransform( this.camera.transform );
+    this.setCameraPose( cameraPose );
 }
 
 this.attachToTarget = function() {
@@ -73,6 +75,7 @@ this.detachFromTarget = function() {
 
 this.setCameraPose = function( pose ) {
     var poseTransform = this.convertPoseToTransform( pose );
+    this.getNearestCollisionDistance( pose[ 1 ], pose[ 2 ], 3, 1000);
     this.camera.transformTo( poseTransform );
 }
 
@@ -97,5 +100,36 @@ this.convertPoseToTransform = function( pose ) {
 this.mounted = function( mount ) {
     this.mountName = mount.name;
 }
+
+this.getPoseFromTransform = function( transform ) {
+    var pitch = Math.acos( transform[ 10 ] );
+    var yawSign = Math.asin( transform[ 1 ] ) < 0 ? -1 : 1;
+    var yaw = yawSign * Math.acos( transform[ 0 ] );
+    var radius = transform[ 12 ] / transform[ 10 ] / transform[ 1 ];
+    return [ radius, yaw, pitch ];
+}
+
+this.getNearestCollisionDistance = function( yaw, pitch, near, far ) {
+    var sy = Math.sin( yaw );
+    var cy = Math.cos( yaw );
+    var sp = Math.sin( pitch );
+    var cp = Math.cos( pitch );
+    var direction = [
+        sp * sy,
+        -sp * cy,
+        cp
+    ];
+    var objectsToCheck = [
+        this.scene.environment.id,
+        this.scene.player.id,
+        this.scene.pickups.id
+    ];
+    var origin = [
+        this.target.worldTransform[ 12 ],
+        this.target.worldTransform[ 13 ],
+        this.target.worldTransform[ 14 ]
+    ];
+    var results = this.scene.raycast( origin, direction, near, far, true, objectsToCheck );
+    console.log( results );
 
 //@ sourceURL=source/gameCamera.js

--- a/source/gameCamera.js
+++ b/source/gameCamera.js
@@ -53,8 +53,11 @@ this.followTarget = function( transform ) {
         transform[ 13 ],
         transform[ 14 ]
     ];
-    var cameraPose = this.getPoseFromTransform( this.camera.transform );
-    this.setCameraPose( cameraPose );
+    // The following code is for checking camera collisions as the target object
+    //   is moving. It currently is slow and fights with the collision handling
+    //   in view/navigation.js.
+    // var cameraPose = this.getPoseFromTransform( this.camera.transform );
+    // this.setCameraPose( cameraPose );
 }
 
 this.attachToTarget = function() {

--- a/source/gameCamera.vwf.yaml
+++ b/source/gameCamera.vwf.yaml
@@ -20,6 +20,8 @@
 
 ---
 extends: http://vwf.example.com/node3.vwf
+implements:
+  - http://vwf.example.com/sceneGetter.vwf
 properties:
   target:
   mountName:
@@ -35,6 +37,7 @@ methods:
   detachFromTarget:
   setCameraPose:
   convertPoseToTransform:
+  getPoseFromTransform:
 events:
   mounted:
 children:

--- a/source/gameCamera.vwf.yaml
+++ b/source/gameCamera.vwf.yaml
@@ -24,7 +24,7 @@ implements:
   - http://vwf.example.com/sceneGetter.vwf
 properties:
   target:
-  mountName:
+  mount:
   lastTargetPosition: [ 0, 0, 0 ]
   followingTarget: true
   followRotation: false

--- a/source/scenario/scenario1a.vwf.yaml
+++ b/source/scenario/scenario1a.vwf.yaml
@@ -153,14 +153,6 @@ children:
           - playSound:
             - ALVO14_Rover
 
-        setCameraView:
-          triggerCondition:
-          - onBlocklyStarted:
-            - rover
-          actions:
-          - setCinematicCameraView:
-            - [ 13, 15, -15 ]
-
   grid:
     includes: source/grid.vwf
     properties:

--- a/source/scenario/scenario1b.vwf.yaml
+++ b/source/scenario/scenario1b.vwf.yaml
@@ -173,14 +173,6 @@ children:
           - writeToBlackboard:
             - Level1bHint2
 
-        setCameraView:
-          triggerCondition:
-          - onBlocklyStarted:
-            - rover
-          actions:
-          - setCinematicCameraView:
-            - [ 13, 15, -15 ]
-
   grid:
     includes: source/grid.vwf
     properties:

--- a/source/scenario/scenario1c.vwf.yaml
+++ b/source/scenario/scenario1c.vwf.yaml
@@ -176,14 +176,6 @@ children:
           - playSound:
             - ALVO41_Rover
 
-        setCameraView:
-          triggerCondition:
-          - onBlocklyStarted:
-            - rover
-          actions:
-          - setCinematicCameraView:
-            - [ 13, 15, -15 ]
-
   grid:
     includes: source/grid.vwf
     properties:

--- a/source/scenario/scenario1d.vwf.yaml
+++ b/source/scenario/scenario1d.vwf.yaml
@@ -141,14 +141,6 @@ children:
           - playSound:
             - ALVO18_Rover
 
-        setCameraView:
-          triggerCondition:
-          - onBlocklyStarted:
-            - rover
-          actions:
-          - setCinematicCameraView:
-            - [ 13, 15, -15 ]
-
   grid:
     includes: source/grid.vwf
     properties:

--- a/source/scenario/scenario1e.vwf.yaml
+++ b/source/scenario/scenario1e.vwf.yaml
@@ -151,14 +151,6 @@ children:
           - playSound:
             - ALVO19_Rover
 
-        setCameraView:
-          triggerCondition:
-          - onBlocklyStarted:
-            - rover
-          actions:
-          - setCinematicCameraView:
-            - [ 13, 15, -15 ]
-
   grid:
     includes: source/grid.vwf
     properties:

--- a/source/scenario/scenario1f.vwf.yaml
+++ b/source/scenario/scenario1f.vwf.yaml
@@ -130,14 +130,6 @@ children:
           - playSound:
             - ALVO35_Rover
 
-        setCameraView:
-          triggerCondition:
-          - onBlocklyStarted:
-            - rover
-          actions:
-          - setCinematicCameraView:
-            - [ 13, 15, -15 ]
-
   grid:
     includes: source/grid.vwf
     properties:

--- a/source/scenario/scenario1g.vwf.yaml
+++ b/source/scenario/scenario1g.vwf.yaml
@@ -128,14 +128,6 @@ children:
           - callOutObjective:
             - [ 8, 2 ]
 
-        setCameraView:
-          triggerCondition:
-          - onBlocklyStarted:
-            - rover
-          actions:
-          - setCinematicCameraView:
-            - [ 13, 15, -15 ]
-
   grid:
     includes: source/grid.vwf
     properties:

--- a/source/scenario/scenario1h.vwf.yaml
+++ b/source/scenario/scenario1h.vwf.yaml
@@ -164,14 +164,6 @@ children:
             - /pickups/radio
             - 3
 
-        setCameraView:
-          triggerCondition:
-          - onBlocklyStarted:
-            - rover
-          actions:
-          - setCinematicCameraView:
-            - [ 13, 15, -15 ]
-
   grid:
     includes: source/grid.vwf
     properties:

--- a/source/scenario/scenario_dummy.vwf.yaml
+++ b/source/scenario/scenario_dummy.vwf.yaml
@@ -166,14 +166,6 @@ children:
           - setObjective:
             - "Explore the Cartesian Plane!"
 
-        setCameraView:
-          triggerCondition:
-          - onBlocklyStarted:
-            - rover
-          actions:
-          - setCinematicCameraView:
-            - [ 13, 15, -15 ]
-
         disableFailOnIncomplete:
           triggerCondition:
           - or:

--- a/source/scene.js
+++ b/source/scene.js
@@ -274,7 +274,7 @@ this.setUpRoverListeners = function() {
 this.displayTiles = function( isVisible ) {
     if ( isVisible !== this.gridTileGraph.mapTiles.groupVisible ) {
         this.gridTileGraph.mapTiles.groupVisible = isVisible;
-        if ( isVisible && this.gameCam.mountName !== "topDown" ) {
+        if ( isVisible && this.gameCam.mount.name !== "topDown" ) {
             this.gameCam.setCameraMount( "topDown" );
         }
         this.toggledTiles( isVisible );
@@ -284,7 +284,7 @@ this.displayTiles = function( isVisible ) {
 this.displayGraph = function( isVisible ) {
     if ( isVisible !== this.blocklyGraph.graphVisible ) {
         this.blocklyGraph.graphVisible = isVisible;
-        if ( isVisible && this.gameCam.mountName !== "topDown" ) {
+        if ( isVisible && this.gameCam.mount.name !== "topDown" ) {
             this.gameCam.setCameraMount( "topDown" );
         }
         this.toggledGraph( isVisible );
@@ -389,8 +389,8 @@ this.selectBlocklyNode = function( nodeID ) {
             this.blockly_activeNodeID = nodeID;
         }
         if ( node.defaultMount && this.gameCam.target !== node ) {
-            if ( node.hasMount( this.gameCam.mountName ) ) {
-                mountName = this.gameCam.mountName;
+            if ( node.hasMount( this.gameCam.mount.name ) ) {
+                mountName = this.gameCam.mount.name;
             }
             this.gameCam.setCameraTarget( node, mountName );
             this.hud.selectRover( nodeID );

--- a/source/view/navigation.js
+++ b/source/view/navigation.js
@@ -105,8 +105,7 @@ function handleMouseNavigation( deltaX, deltaY, navObject, navMode, rotationSpee
                     matrixWorld[ 13 ] - matrix[ 13 ],
                     matrixWorld[ 14 ] - matrix[ 14 ]
                 ];
-                var direction = [ matrix[ 12 ], matrix[ 13 ], matrix[ 14 ] ];
-                var distance = getNearestCollisionDistance( origin, direction, thirdPerson_MinZoom, thirdPerson_MaxZoom );
+                var distance = getNearestCollisionDistance( origin, newYaw, newPitch, thirdPerson_MinZoom, thirdPerson_MaxZoom );
                 if ( !thirdPerson_ZoomLevel ) {
                     thirdPerson_ZoomLevel = radius;
                 }
@@ -158,8 +157,7 @@ function handleScroll( wheelDelta, navObject, navMode, rotationSpeed, translatio
                 matrixWorld[ 13 ] - matrix[ 13 ],
                 matrixWorld[ 14 ] - matrix[ 14 ]
             ];
-            var direction = [ matrix[ 12 ], matrix[ 13 ], matrix[ 14 ] ];
-            var distance = getNearestCollisionDistance( origin, direction, thirdPerson_MinZoom, thirdPerson_MaxZoom );
+            var distance = getNearestCollisionDistance( origin, curYaw, curPitch, thirdPerson_MinZoom, thirdPerson_MaxZoom );
             if ( distance ) {
                 radius = Math.min( radius, distance * 0.8 );
             }
@@ -227,8 +225,7 @@ function moveNavObject( deltaX, deltaY, navObject, navMode, rotationSpeed, trans
                 matrixWorld[ 13 ] - matrix[ 13 ],
                 matrixWorld[ 14 ] - matrix[ 14 ]
             ];
-            var direction = [ matrix[ 12 ], matrix[ 13 ], matrix[ 14 ] ];
-            var distance = getNearestCollisionDistance( origin, direction, thirdPerson_MinZoom, thirdPerson_MaxZoom );
+            var distance = getNearestCollisionDistance( origin, newYaw, newPitch, thirdPerson_MinZoom, thirdPerson_MaxZoom );
             if ( !thirdPerson_ZoomLevel ) {
                 thirdPerson_ZoomLevel = radius;
             }
@@ -287,7 +284,16 @@ function getNewTransformMatrix( radius, yaw, pitch ) {
     return matrix;
 }
 
-function getNearestCollisionDistance( origin, direction, near, far ) {
+function getNearestCollisionDistance( origin, yaw, pitch, near, far ) {
+    var sy = Math.sin( yaw );
+    var cy = Math.cos( yaw );
+    var sp = Math.sin( pitch );
+    var cp = Math.cos( pitch );
+    var direction = [
+        sp * sy,
+        -sp * cy,
+        cp
+    ];
     origin = new THREE.Vector3( origin[ 0 ], origin[ 1 ], origin[ 2 ] );
     direction = new THREE.Vector3( direction[ 0 ], direction[ 1 ], direction[ 2 ] );
     direction.normalize();


### PR DESCRIPTION
These are the changes for camera collisions and the less strictly controlled third person camera. These changes do not include checking for camera collisions as the camera target is moving and camera itself is stationary. My solution for that caused some fighting between the view and model. I still need to find a better place to put that.

What is included:
- Removed camera snapping when running blockly
- Remember last camera pose in third person
- Push camera inward when colliding with world
  - Collides when user input is moving the camera
  - Collides when camera mode is initially set (when switching targets or view modes)

@kadst43 @AmbientOSX 