### PR TITLE
Projected grid shader

### DIFF
--- a/source/shaders/projectedGrid.vwf.yaml
+++ b/source/shaders/projectedGrid.vwf.yaml
@@ -1,0 +1,200 @@
+---
+extends: http://vwf.example.com/shaderMaterial.vwf
+properties:
+  lights: true
+  uniforms:
+    gridVisible:
+      type: "i"
+      value: 1
+    gridOffset:
+      type: "f"
+      value: 0
+    gridInterval:
+      type: "f"
+      value: 10
+    gridLineThickness:
+      type: "f"
+      value: 2
+    gridColor:
+      type: "c"
+      value: 0xFF4411
+    laserFocus:
+      type: "f"
+      value: 5
+    diffuseMap:
+      type: "t"
+      value: 0
+    normalMap:
+      type: "t"
+      value: 0
+    specularMap:
+      type: "t"
+      value: 0
+    diffuse:
+      type: "c"
+      value: 0xFFFFFF
+    ambient:
+      type: "c"
+      value: 0xFFFFFF
+    emissive:
+      type: "c"
+      value: 0x000000
+    specular:
+      type: "c"
+      value: 0xFFFFFF
+    normalScale:
+      type: "v2"
+      value: [ 1, 1 ]
+    opacity:
+      type: "f"
+      value: 1
+    shininess:
+      type: "f"
+      value: 30
+    ambientLightColor:
+      type: "fv"
+      value: []
+    directionalLightColor:
+      type: "fv"
+      value: []
+    directionalLightDirection:
+      type: "fv"
+      value: []
+    pointLightColor:
+      type: "fv"
+      value: []
+    pointLightPosition:
+      type: "fv"
+      value: []
+    pointLightDistance:
+      type: "fv1"
+      value: []
+    spotLightColor:
+      type: "fv"
+      value: []
+    spotLightPosition:
+      type: "fv"
+      value: []
+    spotLightDistance:
+      type: "fv1"
+      value: []
+    spotLightDirection:
+      type: "fv"
+      value: []
+    spotLightAngleCos:
+      type: "fv1"
+      value: []
+    spotLightExponent:
+      type: "fv1"
+      value: []
+    hemisphereLightSkyColor:
+      type: "fv"
+      value: []
+    hemisphereLightGroundColor:
+      type: "fv"
+      value: []
+    hemisphereLightDirection:
+      type: "fv1"
+      value: []
+  vertexShader: |
+    varying vec2 vUv;
+    varying vec3 vWorldPosition;
+    varying vec3 vViewPosition;
+    varying vec3 vNormal;
+    void main() {
+      vec3 objectNormal;
+      objectNormal = normal;
+      vec3 transformedNormal = normalMatrix * objectNormal;
+      vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+      vWorldPosition = worldPosition.xyz;
+      vNormal = normalize( transformedNormal );
+      vUv = uv;
+      vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+      vViewPosition = -mvPosition.xyz;
+      gl_Position = projectionMatrix * mvPosition;
+    }
+  fragmentShader: |
+    #extension GL_OES_standard_derivatives : enable
+    uniform sampler2D diffuseMap;
+    uniform sampler2D normalMap;
+    uniform sampler2D specularMap;
+    uniform vec3 diffuse;
+    uniform float opacity;
+    uniform vec3 ambient;
+    uniform vec3 emissive;
+    uniform vec3 specular;
+    uniform float shininess;
+    uniform vec2 normalScale;
+    uniform vec3 ambientLightColor;
+    uniform vec3 directionalLightColor[ MAX_DIR_LIGHTS ];
+    uniform vec3 directionalLightDirection[ MAX_DIR_LIGHTS ];
+    // PROJECTED GRID SHADER UNIFORMS START
+    uniform int gridVisible;
+    uniform float gridOffset;
+    uniform float gridInterval;
+    uniform float gridLineThickness;
+    uniform vec3 gridColor;
+    uniform float laserFocus;
+    // PROJECTED GRID SHADER UNIFORMS END
+    varying vec2 vUv;
+    varying vec3 vWorldPosition;
+    varying vec3 vViewPosition;
+    varying vec3 vNormal;
+    vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 mapNormal ) {
+      vec3 q0 = dFdx( eye_pos.xyz );
+      vec3 q1 = dFdy( eye_pos.xyz );
+      vec2 st0 = dFdx( vUv.st );
+      vec2 st1 = dFdy( vUv.st );
+      vec3 S = normalize( q0 * st1.t - q1 * st0.t );
+      vec3 T = normalize( -q0 * st1.s + q1 * st0.s );
+      vec3 N = normalize( surf_norm );
+      vec3 mapN = mapNormal * 2.0 - 1.0;
+      mapN.xy = normalScale * mapN.xy;
+      mat3 tsn = mat3( S, T, N );
+      return normalize( tsn * mapN );
+    }
+    void main() {
+        gl_FragColor = texture2D( diffuseMap, vUv );
+        float specularStrength = texture2D( specularMap, vUv ).r;
+        vec3 normal = normalize( vNormal );
+        vec3 viewPosition = normalize( vViewPosition );
+        vec3 mapNormal = texture2D( normalMap, vUv ).rgb;
+        normal = perturbNormal2Arb( -vViewPosition, normal, mapNormal );
+        vec3 dirDiffuse = vec3( 0.0 );
+        vec3 dirSpecular = vec3( 0.0 );
+        for( int i = 0; i < MAX_DIR_LIGHTS; i ++ ) {
+          vec4 lDirection = viewMatrix * vec4( directionalLightDirection[ i ], 0.0 );
+          vec3 dirVector = normalize( lDirection.xyz );
+          float dotProduct = dot( normal, dirVector );
+          float dirDiffuseWeight = max( dotProduct, 0.0 );
+          dirDiffuse += diffuse * directionalLightColor[ i ] * dirDiffuseWeight;
+          vec3 dirHalfVector = normalize( dirVector + viewPosition );
+          float dirDotNormalHalf = max( dot( normal, dirHalfVector ), 0.0 );
+          float dirSpecularWeight = specularStrength * max( pow( dirDotNormalHalf, shininess ), 0.0 );
+          float specularNormalization = ( shininess + 2.0 ) / 8.0;
+          vec3 schlick = specular + vec3( 1.0 - specular ) * pow( max( 1.0 - dot( dirVector, dirHalfVector ), 0.0 ), 5.0 );
+          dirSpecular += schlick * directionalLightColor[ i ] * dirSpecularWeight * dirDiffuseWeight * specularNormalization;
+        }
+        vec3 totalDiffuse = vec3( 0.0 );
+        vec3 totalSpecular = vec3( 0.0 );
+        totalDiffuse += dirDiffuse;
+        totalSpecular += dirSpecular;
+        gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor * ambient ) + totalSpecular;
+        // PROJECTED GRID SHADER START
+        if ( gridVisible == 1 ) {
+          float intervalHalf = gridInterval / 2.0;
+          float lineBuffer = gridInterval - gridLineThickness;
+          vec2 gridLine = vec2( intervalHalf - mod( vWorldPosition.xy + gridOffset, gridInterval ) );
+          gridLine = max( gridLine, -1.0 * gridLine ) + lineBuffer / ( lineBuffer + intervalHalf );
+          vec3 laserColor = max( ( 1.0 - gridColor ) * laserFocus, 1.0 );
+          float laserFactor = 0.0;
+          if ( gridLine.x < 1.0 ) {
+            laserFactor = min( 1.0 - pow( gridLine.x, 4.0 ), 1.0 );
+          }
+          if ( gridLine.y < 1.0 ) {
+            laserFactor = max( laserFactor, min( 1.0 - pow( gridLine.y, 4.0 ), 1.0 ) );
+          }
+          gl_FragColor.xyz += ( pow( vec3( laserFactor ), laserColor ) );
+        }
+        // PROJECTED GRID SHADER END
+    }

--- a/source/shaders/texturedShader.vwf.yaml
+++ b/source/shaders/texturedShader.vwf.yaml
@@ -2,53 +2,6 @@
 extends: http://vwf.example.com/shaderMaterial.vwf
 properties:
   lights: true
-  diffuseMap:
-    set: |
-      this.uniforms.diffuseMap.value = this.newTexture( value );
-      this.diffuseMap = value;
-  normalMap:
-    set: |
-      this.uniforms.normalMap.value = this.newTexture( value );
-      this.normalMap = value;
-  specularMap:
-    set: |
-      this.uniforms.specularMap.value = this.newTexture( value );
-      this.specularMap = value;
-  diffuse:
-    set: |
-      this.uniforms.diffuse.value = this.newColor( value );
-      this.diffuse = value;
-    value: [ 255, 255, 255 ]
-  ambient:
-    set: |
-      this.uniforms.ambient.value = this.newColor( value );
-      this.ambient = value;
-    value: [ 255, 255, 255 ]
-  emissive:
-    set: |
-      this.uniforms.emissive.value = this.newColor( value );
-      this.emissive = value;
-    value: [ 0, 0, 0 ]
-  specular:
-    set: |
-      this.uniforms.specular.value = this.newColor( value );
-      this.specular = value;
-    value: [ 255, 255, 255 ]
-  normalScale:
-    set: |
-      this.uniforms.normalScale.value = new THREE.Vector2( value[ 0 ], value[ 1 ] );
-      this.normalScale = value;
-    value: [ 1, 1 ]
-  opacity:
-    set: |
-      this.uniforms.opacity.value = value;
-      this.opacity = value;
-    value: 1
-  shininess:
-    set: |
-      this.uniforms.shininess.value = Math.max( value, 1 );
-      this.shininess = value;
-    value: 30
   uniforms:
     diffuseMap:
       type: "t"
@@ -61,19 +14,19 @@ properties:
       value: 0
     diffuse:
       type: "c"
-      value: 0
+      value: 0xFFFFFF
     ambient:
       type: "c"
-      value: 0
+      value: 0xFFFFFF
     emissive:
       type: "c"
-      value: 0
+      value: 0x000000
     specular:
       type: "c"
-      value: 0
+      value: 0xFFFFFF
     normalScale:
       type: "v2"
-      value: 0
+      value: [ 1, 1 ]
     opacity:
       type: "f"
       value: 1


### PR DESCRIPTION
Here's a basic version of the projected grid shader. I don't have an example in mars-game yet, but I do have a screenshot from a test application:

![projected_grid](https://cloud.githubusercontent.com/assets/4560557/7440821/4808a0b2-f099-11e4-94a2-6ec0a0df75c3.png)

This is the mix map shader + the projected grid. There are several uniforms that affect the appearance of the grid (color, thickness, etc). I'm still modifying how these uniforms behave, so this isn't done yet. I just wanted to get a preview up.