### PR TITLE
Further tooltip changes

### DIFF
--- a/source/view/tooltips.js
+++ b/source/view/tooltips.js
@@ -24,12 +24,15 @@ function showTooltip( x, y, content ) {
     blocklyBlocks = document.getElementsByClassName("blocklyPath");
 
     for (var i=0;i<blocklyBlocks.length;i++){
-        blocklyBlocks[i].addEventListener("mouseout", removeTooltip, true);
+        blocklyBlocks[i].addEventListener("mouseout", removeTooltipMouseout, true);
     }
+    
+    document.addEventListener("click", removeTooltipClick);
 
     // Return an empty string because blockly gets mad if we don't
     return "";
 }
+
 
 function showTooltipInBlockly( block, content ) {
     if ( block && block.isInFlyout ) {
@@ -44,7 +47,7 @@ function showTooltipInBlockly( block, content ) {
     return "";
 }
 
-function removeTooltip(event) {
+function removeTooltipMouseout(event) {
 
     var removeTip = true;
 
@@ -59,9 +62,14 @@ function removeTooltip(event) {
     if(removeTip){
         $(".tooltip").remove();
         for (var i=0;i<blocklyBlocks.length;i++){
-            blocklyBlocks[i].removeEventListener("mouseout", removeTooltip);
+            blocklyBlocks[i].removeEventListener("mouseout", removeTooltipMouseout);
         }
     }
+}
+
+function removeTooltipClick(event){
+    $(".tooltip").remove();
+    document.removeEventListener("click",removeTooltipClick);
 }
 
 function tooltipContentToHTML( content ) {

--- a/source/view/tooltips.js
+++ b/source/view/tooltips.js
@@ -21,7 +21,11 @@ function showTooltip( x, y, content ) {
     tooltip.style.right = "10px";
     document.body.appendChild( tooltip );
 
-    document.addEventListener( "mousemove", removeTooltip );
+    blocklyBlocks = document.getElementsByClassName("blocklyPath");
+
+    for (var i=0;i<blocklyBlocks.length;i++){
+        blocklyBlocks[i].addEventListener("mouseout", removeTooltip, true);
+    }
 
     // Return an empty string because blockly gets mad if we don't
     return "";
@@ -40,11 +44,24 @@ function showTooltipInBlockly( block, content ) {
     return "";
 }
 
-function removeTooltip() {
-    $( ".tooltip" ).fadeOut( function() {
-        $( ".tooltip" ).remove();
-        document.removeEventListener( "mousemove", removeTooltip );
-    } );
+function removeTooltip(event) {
+
+    var removeTip = true;
+
+    if(event.relatedTarget.getAttribute("class") == "blocklyText"){
+        removeTip = false;
+    }
+    
+    if( event.relatedTarget.parentNode.getAttribute("class") == "blocklyEditableText"){
+        removeTip = false;
+    }
+
+    if(removeTip){
+        $(".tooltip").remove();
+        for (var i=0;i<blocklyBlocks.length;i++){
+            blocklyBlocks[i].removeEventListener("mouseout", removeTooltip);
+        }
+    }
 }
 
 function tooltipContentToHTML( content ) {

--- a/source/view/tooltips.js
+++ b/source/view/tooltips.js
@@ -21,18 +21,11 @@ function showTooltip( x, y, content ) {
     tooltip.style.right = "10px";
     document.body.appendChild( tooltip );
 
-    blocklyBlocks = document.getElementsByClassName("blocklyPath");
-
-    for (var i=0;i<blocklyBlocks.length;i++){
-        blocklyBlocks[i].addEventListener("mouseout", removeTooltipMouseout, true);
-    }
-    
     document.addEventListener("click", removeTooltipClick);
-
+    document.addEventListener("mousemove", removeTooltipHoverout);
     // Return an empty string because blockly gets mad if we don't
     return "";
 }
-
 
 function showTooltipInBlockly( block, content ) {
     if ( block && block.isInFlyout ) {
@@ -47,23 +40,15 @@ function showTooltipInBlockly( block, content ) {
     return "";
 }
 
-function removeTooltipMouseout(event) {
+function removeTooltipHoverout(event){
 
-    var removeTip = true;
-
-    if(event.relatedTarget.getAttribute("class") == "blocklyText"){
-        removeTip = false;
-    }
-    
-    if( event.relatedTarget.parentNode.getAttribute("class") == "blocklyEditableText"){
-        removeTip = false;
-    }
-
-    if(removeTip){
+    if(!(event.target.getAttribute("class") == "blocklyPath" || 
+        event.target.getAttribute("class") == "blocklyText" || 
+        event.target.parentNode.getAttribute("class") == "blocklyEditableText" ||
+        event.target.parentNode.getAttribute("class"))){
         $(".tooltip").remove();
-        for (var i=0;i<blocklyBlocks.length;i++){
-            blocklyBlocks[i].removeEventListener("mouseout", removeTooltipMouseout);
-        }
+        document.removeEventListener("mousemove",removeTooltipHoverout);
+        
     }
 }
 


### PR DESCRIPTION
Makes the tooltips disappear when the mouse hovers out of a specific blocks instead of disappearing whenever a mousemove event is triggered. 