### PR TITLE
New selectRover action

### DIFF
--- a/source/scenario/mission4task1.vwf.yaml
+++ b/source/scenario/mission4task1.vwf.yaml
@@ -128,11 +128,45 @@ properties:
   - setCinematicCameraView:
     - [ 21, -18, -10 ]
 
+  - setProperty:
+    - solarPanel1
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel2
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel3
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel4
+    - visible
+    - false
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf
     properties: 
       triggers$:
+
+        setStartPosition_4_2:
+          triggerCondition:
+          - and:
+            - onScenarioStart:
+            - not:
+              - isAtPosition:
+                - rover2
+                - [ -34, 70 ]
+          actions:
+            - addToGrid:
+              - rover2
+              - [ -34, 70 ]
+
         succeedOnTriangle_4_1:
           group: successOrFailure
           priority: 0

--- a/source/scenario/mission4task1.vwf.yaml
+++ b/source/scenario/mission4task1.vwf.yaml
@@ -83,7 +83,7 @@ properties:
     - true
   - addToGrid:
     - rover2
-    - [ -32, 68 ]
+    - [ -34, 70 ]
   - setProperty:
     - rover2
     - battery
@@ -111,19 +111,7 @@ properties:
     - [ -10, 0 ]
     - [ -10, 3 ]
     - [ -13, 0 ]
-  - setCinematicCameraView:
-    - [ 16.316, 65, -15 ]
-#  - addToGrid:
-#    - solarPanel1
-#    - [ -32, 77 ]
-#  - setProperty:
-#    - solarPanel1
-#    - visible
-#    - true
-#  - setProperty:
-#    - solarPanel1
-#    - built
-#    - true
+
   - setProperty:
     - blocklyLine
     - visible
@@ -136,6 +124,9 @@ properties:
 
   - selectRover:
     - rover2
+
+  - setCinematicCameraView:
+    - [ 21, -18, -10 ]
 
 children:
   triggerManager:

--- a/source/scenario/mission4task1.vwf.yaml
+++ b/source/scenario/mission4task1.vwf.yaml
@@ -134,6 +134,9 @@ properties:
     - opacity
     - 0
 
+  - selectRover:
+    - rover2
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/mission4task2.vwf.yaml
+++ b/source/scenario/mission4task2.vwf.yaml
@@ -123,6 +123,26 @@ properties:
 
   - selectRover:
     - rover2
+
+  - setProperty:
+    - solarPanel1
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel2
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel3
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel4
+    - visible
+    - false
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf
@@ -136,27 +156,6 @@ children:
             - doOnce:
           actions:
           - openMissionBrief:
-
-        setStartPosition_4_2:
-          triggerCondition:
-          - and:
-            - onScenarioStart:
-            - not:
-              - isAtPosition:
-                - rover2
-                - [ -32, 77 ]
-            - not:
-              - isAtPosition:
-                - rover2
-                - [ -32, 80 ]
-            - not:
-              - isAtPosition:
-                - rover2
-                - [ -35, 77 ]
-          actions:
-            - addToGrid:
-              - rover2
-              - [ -32, 77 ]
 
         succeedOnTriangle_4_2:
           group: successOrFailure

--- a/source/scenario/mission4task2.vwf.yaml
+++ b/source/scenario/mission4task2.vwf.yaml
@@ -121,6 +121,8 @@ properties:
     - opacity
     - 0
 
+  - selectRover:
+    - rover2
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/mission4task3.vwf.yaml
+++ b/source/scenario/mission4task3.vwf.yaml
@@ -122,6 +122,26 @@ properties:
 
   - selectRover:
     - rover2
+
+  - setProperty:
+    - solarPanel1
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel2
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel3
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel4
+    - visible
+    - false    
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/mission4task3.vwf.yaml
+++ b/source/scenario/mission4task3.vwf.yaml
@@ -119,6 +119,9 @@ properties:
     - blocklyLine
     - opacity
     - 0
+
+  - selectRover:
+    - rover2
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/mission4task4.vwf.yaml
+++ b/source/scenario/mission4task4.vwf.yaml
@@ -128,6 +128,9 @@ properties:
     - opacity
     - 0
 
+  - selectRover:
+    - rover2
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/mission4task4.vwf.yaml
+++ b/source/scenario/mission4task4.vwf.yaml
@@ -111,13 +111,6 @@ properties:
     - [ 0, 6 ]
     - [ 6, 0 ]
 
-  - addToGrid:
-    - solarPanel2
-    - [ -19, 80 ]
-  - setProperty:
-    - solarPanel2
-    - scale
-    - [1.2, 1.2, 1.2]
   - setProperty:
     - blocklyLine
     - visible
@@ -131,6 +124,42 @@ properties:
   - selectRover:
     - rover2
 
+  - addToGrid:
+    - solarPanel1
+    - [ -25, 80 ]
+  - setProperty:
+    - solarPanel1
+    - scale
+    - [1.2, 1.2, 1.2]
+  - setProperty:
+    - solarPanel1
+    - rotation
+    - [0 ,0 ,1 , 90 ]
+  - addToGrid:
+    - solarPanel2
+    - [ -19, 80 ]
+  - setProperty:
+    - solarPanel2
+    - scale
+    - [1.2, 1.2, 1.2]
+  - setProperty:
+    - solarPanel1
+    - visible
+    - true
+  - buildBaseComponent:
+    - solarPanel1
+  - setProperty:
+    - solarPanel2
+    - visible
+    - false
+  - setProperty:
+    - solarPanel3
+    - visible
+    - false
+  - setProperty:
+    - solarPanel4
+    - visible
+    - false
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/mission4task5.vwf.yaml
+++ b/source/scenario/mission4task5.vwf.yaml
@@ -133,6 +133,37 @@ properties:
 
   - selectRover:
     - rover2
+  - addToGrid:
+    - solarPanel1
+    - [ -25, 80 ]
+  - addToGrid:
+    - solarPanel2
+    - [ -19, 80 ]
+  - setProperty:
+    - solarPanel1
+    - visible
+    - true
+  - setProperty:
+    - solarPanel1
+    - built
+    - false
+  - setProperty:
+    - solarPanel2
+    - visible
+    - true
+  - setProperty:
+    - solarPanel2
+    - built
+    - false
+  - setProperty:
+    - solarPanel3
+    - visible
+    - false
+
+  - setProperty:
+    - solarPanel4
+    - visible
+    - false
 
 children:
   triggerManager:

--- a/source/scenario/mission4task5.vwf.yaml
+++ b/source/scenario/mission4task5.vwf.yaml
@@ -131,6 +131,9 @@ properties:
     - opacity
     - 0
 
+  - selectRover:
+    - rover2
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/mission4task6.vwf.yaml
+++ b/source/scenario/mission4task6.vwf.yaml
@@ -132,6 +132,9 @@ properties:
     - opacity
     - 0
 
+  - selectRover:
+    - rover2
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/mission4task6.vwf.yaml
+++ b/source/scenario/mission4task6.vwf.yaml
@@ -134,6 +134,57 @@ properties:
 
   - selectRover:
     - rover2
+  - addToGrid:
+    - solarPanel1
+    - [ -25, 80 ]
+  - setProperty:
+    - solarPanel1
+    - scale
+    - [1.2, 1.2, 1.2]
+  - setProperty:
+    - solarPanel1
+    - rotation
+    - [0 ,0 ,1 , 90 ]
+  - addToGrid:
+    - solarPanel2
+    - [ -19, 80 ]
+  - setProperty:
+    - solarPanel2
+    - scale
+    - [1.2, 1.2, 1.2]
+  - addToGrid:
+    - solarPanel3
+    - [ -25, 74 ]
+  - setProperty:
+    - solarPanel3
+    - rotation
+    - [0 ,0 ,1 , 180 ]
+  - setProperty:
+    - solarPanel3
+    - scale
+    - [1.2, 1.2, 1.2]
+  - setProperty:
+    - solarPanel1
+    - visible
+    - true
+  - buildBaseComponent:
+    - solarPanel1
+  - setProperty:
+    - solarPanel2
+    - visible
+    - true
+  - buildBaseComponent:
+    - solarPanel2
+  - setProperty:
+    - solarPanel3
+    - visible
+    - true
+  - buildBaseComponent:
+    - solarPanel3
+  - setProperty:
+    - solarPanel4
+    - visible
+    - false
 
 children:
   triggerManager:

--- a/source/scenario/scenario1a.vwf.yaml
+++ b/source/scenario/scenario1a.vwf.yaml
@@ -90,6 +90,9 @@ properties:
     - opacity
     - 0
 
+  - selectRover:
+    - rover
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario1b.vwf.yaml
+++ b/source/scenario/scenario1b.vwf.yaml
@@ -91,6 +91,9 @@ properties:
     - opacity
     - 0
 
+  - selectRover:
+    - rover
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario1c.vwf.yaml
+++ b/source/scenario/scenario1c.vwf.yaml
@@ -84,6 +84,9 @@ properties:
     - opacity
     - 0
 
+  - selectRover:
+    - rover
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario1d.vwf.yaml
+++ b/source/scenario/scenario1d.vwf.yaml
@@ -24,14 +24,7 @@ properties:
     - videoManager  
     - url 
     - [ "assets/video/success_cinematic.webm", "assets/video/success_cinematic.mp4" ]
-  - setProperty:
-    - rover3
-    - visible
-    - false
-  - setProperty:
-    - rover2
-    - visible
-    - false
+
   - setProperty:
     - rover
     - battery
@@ -57,6 +50,16 @@ properties:
   - addToGrid:
     - rover
     - [ 0, 1 ]
+  - selectRover:
+    - rover
+  - setProperty:
+    - rover3
+    - visible
+    - false
+  - setProperty:
+    - rover2
+    - visible
+    - false
   - setPickupActive:
     - helicam
     - false
@@ -83,6 +86,7 @@ properties:
     - blocklyLine
     - opacity
     - 0
+    
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario1e.vwf.yaml
+++ b/source/scenario/scenario1e.vwf.yaml
@@ -84,6 +84,9 @@ properties:
     - opacity
     - 0
 
+  - selectRover:
+    - rover
+    
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario1f.vwf.yaml
+++ b/source/scenario/scenario1f.vwf.yaml
@@ -78,7 +78,9 @@ properties:
     - blocklyLine
     - opacity
     - 0
-
+  - selectRover:
+    - rover
+    
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario1g.vwf.yaml
+++ b/source/scenario/scenario1g.vwf.yaml
@@ -80,7 +80,9 @@ properties:
     - blocklyLine
     - opacity
     - 0
-
+  - selectRover:
+    - rover
+    
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario1h.vwf.yaml
+++ b/source/scenario/scenario1h.vwf.yaml
@@ -83,7 +83,8 @@ properties:
     - blocklyLine
     - opacity
     - 0
-
+  - selectRover:
+    - rover
 
 children:
   triggerManager:

--- a/source/scenario/scenario2a.vwf.yaml
+++ b/source/scenario/scenario2a.vwf.yaml
@@ -84,6 +84,9 @@ properties:
     - opacity
     - 1
 
+  - selectRover:
+    - rover
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario2b.vwf.yaml
+++ b/source/scenario/scenario2b.vwf.yaml
@@ -77,6 +77,9 @@ properties:
     - opacity
     - 1
 
+  - selectRover:
+    - rover
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario2c.vwf.yaml
+++ b/source/scenario/scenario2c.vwf.yaml
@@ -75,7 +75,8 @@ properties:
     - blocklyLine
     - opacity
     - 1
-
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario2d.vwf.yaml
+++ b/source/scenario/scenario2d.vwf.yaml
@@ -76,6 +76,9 @@ properties:
     - blocklyLine
     - opacity
     - 1
+
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario2e.vwf.yaml
+++ b/source/scenario/scenario2e.vwf.yaml
@@ -76,6 +76,9 @@ properties:
     - blocklyLine
     - opacity
     - 1
+
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario2f.vwf.yaml
+++ b/source/scenario/scenario2f.vwf.yaml
@@ -72,7 +72,8 @@ properties:
     - blocklyLine
     - opacity
     - 1
-
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario3a.vwf.yaml
+++ b/source/scenario/scenario3a.vwf.yaml
@@ -73,6 +73,9 @@ properties:
     - opacity
     - 1
 
+  - selectRover:
+    - rover
+
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario3b.vwf.yaml
+++ b/source/scenario/scenario3b.vwf.yaml
@@ -70,7 +70,8 @@ properties:
     - blocklyLine
     - opacity
     - 1
-
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario3c.vwf.yaml
+++ b/source/scenario/scenario3c.vwf.yaml
@@ -73,7 +73,8 @@ properties:
     - blocklyLine
     - opacity
     - 1
-
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario3d.vwf.yaml
+++ b/source/scenario/scenario3d.vwf.yaml
@@ -70,6 +70,8 @@ properties:
     - blocklyLine
     - opacity
     - 1
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/scenario3e.vwf.yaml
+++ b/source/scenario/scenario3e.vwf.yaml
@@ -67,7 +67,8 @@ properties:
     - blocklyLine
     - opacity
     - 1
-
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/temporarymission3task1.vwf.yaml
+++ b/source/scenario/temporarymission3task1.vwf.yaml
@@ -84,7 +84,8 @@ properties:
     - blocklyLine
     - opacity
     - 1
-
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/scenario/temporarymission3task2.vwf.yaml
+++ b/source/scenario/temporarymission3task2.vwf.yaml
@@ -87,7 +87,8 @@ properties:
     - blocklyLine
     - opacity
     - 1
-
+  - selectRover:
+    - rover
 children:
   triggerManager:
     extends: ../triggers/triggerManager.vwf

--- a/source/triggers/actions/action_selectRover.js
+++ b/source/triggers/actions/action_selectRover.js
@@ -1,0 +1,41 @@
+// Copyright 2014 Lockheed Martin Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may 
+// not use this file except in compliance with the License. You may obtain 
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+this.onGenerated = function( params, generator, payload ) {
+    if ( !this.initAction( params, generator, payload ) ) {
+        return false;
+    }
+
+    if ( !params || ( params.length !== 1 ) ) {
+        this.logger.errorx( "onGenerated", 
+                            "This action requires one argument: " +
+                            "an array containing the radius (meters), yaw " +
+                            "(degrees), and pitch (degrees) of the camera." );
+        return false;
+    }
+
+    this.hope = params[ 0 ];
+    if ( !this.pose ) {
+        this.logger.errorx( "onGenerated", "Invalid rover!" );
+        return false;
+    }
+
+    return true;
+}
+
+this.executeAction = function() {
+    this.scene.setCinematicView( this.pose );
+}
+
+//@ sourceURL=source/triggers/actions/action_setCinematicCameraView.js

--- a/source/triggers/actions/action_selectRover.js
+++ b/source/triggers/actions/action_selectRover.js
@@ -20,14 +20,13 @@ this.onGenerated = function( params, generator, payload ) {
     if ( !params || ( params.length !== 1 ) ) {
         this.logger.errorx( "onGenerated", 
                             "This action requires one argument: " +
-                            "an array containing the radius (meters), yaw " +
-                            "(degrees), and pitch (degrees) of the camera." );
+                            "the name of a rover in the scene." );
         return false;
     }
 
-    this.hope = params[ 0 ];
-    if ( !this.pose ) {
-        this.logger.errorx( "onGenerated", "Invalid rover!" );
+    this.chosenRover = params[ 0 ];
+    if ( !this.chosenRover || !this.findInScene(this.chosenRover)) {
+        this.logger.errorx( "onGenerated", "Invalid rover input!" );
         return false;
     }
 
@@ -35,7 +34,8 @@ this.onGenerated = function( params, generator, payload ) {
 }
 
 this.executeAction = function() {
-    this.scene.setCinematicView( this.pose );
+    var chosenRoverID = this.findInScene(this.chosenRover).id;
+    this.scene.selectBlocklyNode(chosenRoverID);
 }
 
-//@ sourceURL=source/triggers/actions/action_setCinematicCameraView.js
+//@ sourceURL=source/triggers/actions/action_selectRover.js

--- a/source/triggers/actions/action_selectRover.vwf.yaml
+++ b/source/triggers/actions/action_selectRover.vwf.yaml
@@ -16,7 +16,7 @@
 extends: actionProto.vwf
 
 properties:
-  hope:
+  chosenRover:
 
 scripts:
 - source: action_selectRover.js

--- a/source/triggers/actions/action_selectRover.vwf.yaml
+++ b/source/triggers/actions/action_selectRover.vwf.yaml
@@ -1,0 +1,22 @@
+# Copyright 2014 Lockheed Martin Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. You may obtain 
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and 
+# limitations under the License.
+
+--- 
+extends: actionProto.vwf
+
+properties:
+  hope:
+
+scripts:
+- source: action_selectRover.js

--- a/source/triggers/generators/generator_Action.vwf.yaml
+++ b/source/triggers/generators/generator_Action.vwf.yaml
@@ -143,8 +143,8 @@ properties:
     enableBlocklyNodes: "source/triggers/actions/action_enableBlocklyNodes.vwf"
     loadToolbox: "source/triggers/actions/action_loadToolbox.vwf"
 
-    # Allows you to choose which rover is currently active in Blockly/The HUD
-    # arguments: The rover's name (rover, rover2, rover3)
+    # Allows you to choose which rover is currently active in Blockly/the HUD
+    # arguments: chosenRover (the rover's name as declared in the scenario i.e. rover, rover2, rover3)
     selectRover: "source/triggers/actions/action_selectRover.vwf"
 
 

--- a/source/triggers/generators/generator_Action.vwf.yaml
+++ b/source/triggers/generators/generator_Action.vwf.yaml
@@ -143,6 +143,10 @@ properties:
     enableBlocklyNodes: "source/triggers/actions/action_enableBlocklyNodes.vwf"
     loadToolbox: "source/triggers/actions/action_loadToolbox.vwf"
 
+    # Allows you to choose which rover is currently active in Blockly/The HUD
+    # arguments: The rover's name (rover, rover2, rover3)
+    selectRover: "source/triggers/actions/action_selectRover.vwf"
+
 
 scripts:
 - source: generator_Action.js

--- a/source/view/index.js
+++ b/source/view/index.js
@@ -435,7 +435,7 @@ vwf_view.initializedNode = function( nodeID, childID, childExtendsID, childImple
         if (childName == "rover"){
             node.tab.innerHTML = "Manny";
         } else if (childName == "rover2"){
-            node.tab.innerHTML = "Perry";
+            node.tab.innerHTML = "Peregrine";
         } else if (childName == "rover3"){
             node.tab.innerHTML = "Rosie";
         }


### PR DESCRIPTION
Added a new action that allows you to choose which of the rover's toolboxes will be default at the start of a scenario, and will also set the camera to focus on that rover.

Changed Perry's blockly tab to read Peregrine instead.

Changed the starting camera view of mission 4 to a more cinematic view, which shows Manny, Perry, the base pod, and the triangle needed to be drawn from a third person view.

Made some changes that will guarantee the right solar panels will be built when switching to different Missions 4 tasks out of order (i.e. if switching to mission 4 task 6 without having done the preceding 3 tasks, the first three solar panels will be built at the beginning of the task).