### PR TITLE
Nested Blockly Toolbox

### DIFF
--- a/source/scenario/blockly/mission4_perry.xml
+++ b/source/scenario/blockly/mission4_perry.xml
@@ -5,7 +5,8 @@
 <!--    <block type="rover_moveRadial_absolute"></block> -->
     <block type="math_number_field"><field name="VALUE">0</field></block>
     <block type="ordered_pair_config"></block>
-    <block type="draw_triangle"></block>
+    <!--<block type="draw_triangle"></block>-->
+    <block type="draw_triangle" id="10" inline="false" x="60" y="140"><value name="pointA"><block type="ordered_pair_config" id="16" movable="false" inline="true"><value name="XFIELD"><block type="math_number_field" id="34" inline="false" movable = "false"><field name="VALUE">0</field></block></value><value name="YFIELD"><block type="math_number_field" id="43" inline="false" movable = "false"><field name="VALUE">0</field></block></value></block></value><value name="pointB"><block type="ordered_pair_config" id="22" movable="false" inline="true"><value name="XFIELD"><block type="math_number_field" id="44" inline="false" movable = "false"><field name="VALUE">0</field></block></value><value name="YFIELD"><block type="math_number_field" id="42" inline="false" movable = "false"><field name="VALUE">0</field></block></value></block></value><value name="pointC"><block type="ordered_pair_config" id="28" movable="false" inline="true"><value name="XFIELD"><block type="math_number_field" id="40" inline="false" movable = "false"><field name="VALUE">0</field></block></value><value name="YFIELD"><block type="math_number_field" id="41" inline="false" movable = "false"><field name="VALUE">0</field></block></value></block></value></block>
     <block type="controls_sensor_position_x"></block>
     <block type="controls_sensor_position_y"></block>
   </category>

--- a/source/scenario/blockly/scenario1g.xml
+++ b/source/scenario/blockly/scenario1g.xml
@@ -2,7 +2,7 @@
   <category name="Control">
   <block type="rover_moveForward"></block>
   <block type="rover_turn"><field name="DIR">Turn: Left</field></block>
-  <block type="controls_repeat_extended"></block>
+  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
   <block type="math_number_field"><field name="VALUE">0</field></block>
   </category>
 </xml>

--- a/source/scenario/blockly/scenario1h.xml
+++ b/source/scenario/blockly/scenario1h.xml
@@ -2,7 +2,7 @@
   <category name="Control">
   <block type="rover_moveForward"></block>
   <block type="rover_turn"><field name="DIR">Turn: Left</field></block>
-  <block type="controls_repeat_extended"></block>
+  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
   <block type="math_number_field"><field name="VALUE">0</field></block>
   </category>
 </xml>

--- a/source/scenario/blockly/scenario2f.xml
+++ b/source/scenario/blockly/scenario2f.xml
@@ -2,7 +2,7 @@
   <category name="Control">
   <block type="rover_moveForward"></block>
   <block type="rover_turn"><field name="DIR">Turn: Left</field></block>
-  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
+  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">3</field></block></value></block>
   <block type="math_number_field"><field name="VALUE">3</field></block>
   </category>
 </xml>

--- a/source/scenario/blockly/scenario2f.xml
+++ b/source/scenario/blockly/scenario2f.xml
@@ -2,7 +2,8 @@
   <category name="Control">
   <block type="rover_moveForward"></block>
   <block type="rover_turn"><field name="DIR">Turn: Left</field></block>
-  <block type="controls_repeat_extended"></block>
+  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
   <block type="math_number_field"><field name="VALUE">3</field></block>
   </category>
 </xml>
+

--- a/source/scenario/blockly/scenario3a.xml
+++ b/source/scenario/blockly/scenario3a.xml
@@ -4,7 +4,7 @@
   <block type="rover_turn"><field name="DIR">Turn: Left</field></block>
   <block type="controls_sensor_metal"></block>
   <block type="controls_whileUntil"><field name="MODE">WHILE</field></block>
-  <block type="controls_repeat_extended"></block>
+  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
   <block type="math_number_field"><field name="VALUE">0</field></block>
   </category>
 </xml>

--- a/source/scenario/blockly/scenario3b.xml
+++ b/source/scenario/blockly/scenario3b.xml
@@ -4,7 +4,7 @@
   <block type="rover_turn"><field name="DIR">Turn: Left</field></block>
   <block type="controls_sensor_metal"></block>
   <block type="controls_whileUntil"><field name="MODE">WHILE</field></block>
-  <block type="controls_repeat_extended"></block>
+  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
   <block type="math_number_field"><field name="VALUE">0</field></block>
   </category>
 </xml>

--- a/source/scenario/blockly/scenario3c.xml
+++ b/source/scenario/blockly/scenario3c.xml
@@ -4,7 +4,7 @@
   <block type="rover_turn"><field name="DIR">Turn: Left</field></block>
   <block type="controls_sensor_metal"></block>
   <block type="controls_whileUntil"><field name="MODE">WHILE</field></block>
-  <block type="controls_repeat_extended"></block>
+  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
   <block type="math_number_field"><field name="VALUE">0</field></block>
   </category>
 </xml>

--- a/source/scenario/blockly/scenario3d.xml
+++ b/source/scenario/blockly/scenario3d.xml
@@ -4,7 +4,7 @@
   <block type="rover_turn"><field name="DIR">Turn: Left</field></block>
   <block type="controls_sensor_metal"></block>
   <block type="controls_whileUntil"><field name="MODE">WHILE</field></block>
-  <block type="controls_repeat_extended"></block>
+  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
   <block type="math_number_field"><field name="VALUE">0</field></block>
   </category>
 </xml>

--- a/source/scenario/blockly/scenario3e.xml
+++ b/source/scenario/blockly/scenario3e.xml
@@ -4,7 +4,7 @@
   <block type="rover_turn"><field name="DIR">Turn: Left</field></block>
   <block type="controls_sensor_metal"></block>
   <block type="controls_whileUntil"><field name="MODE">WHILE</field></block>
-  <block type="controls_repeat_extended"></block>
+  <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
   <block type="math_number_field"><field name="VALUE">0</field></block>
   </category>
 </xml>

--- a/source/scenario/blockly/scenario_dummy.xml
+++ b/source/scenario/blockly/scenario_dummy.xml
@@ -25,7 +25,7 @@
     <block type="logic_boolean"></block>
     <block type="controls_if_nomut"></block>
     <block type="controls_if_else_nomut"></block>
-    <block type="controls_repeat_extended"></block>
+    <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
     <block type="controls_whileUntil"><field name="MODE">WHILE</field></block>
   </category>
   <category name="Numbers / Math">

--- a/source/scenario/blockly/scenario_dummy_perry.xml
+++ b/source/scenario/blockly/scenario_dummy_perry.xml
@@ -26,7 +26,7 @@
     <block type="logic_boolean"></block>
     <block type="controls_if_nomut"></block>
     <block type="controls_if_else_nomut"></block>
-    <block type="controls_repeat_extended"></block>
+    <block type="controls_repeat_extended" id="69" inline="true" x="60" y="100"><value name="TIMES"><block type="math_number_field" id="74" inline="false"><field name="VALUE">0</field></block></value></block>
     <block type="controls_whileUntil"><field name="MODE">WHILE</field></block>
   </category>
   <category name="Numbers / Math">


### PR DESCRIPTION
Changed createTriangle and the forLoop block so that they have pre-built inputs set to 0 even while in the toolbox. This cuts down on the number of blocks you have to drag over.