### PR TITLE
Camera updates

### DIFF
--- a/index.vwf.yaml
+++ b/index.vwf.yaml
@@ -88,6 +88,7 @@ methods:
   removeAxisOffset:
   createNaniteSystem:
   deleteNaniteSystem:
+  switchToHelicamView:
 events:
   gameStarted:
   scenarioReset:
@@ -99,6 +100,7 @@ events:
   clearBlockly:
   selectLastBlock:
   updatedBlocklyVariable:
+  selectedRover:
   showCommsImage:
   hideCommsImage:
   blockExecuted:
@@ -316,6 +318,7 @@ children:
           castShadows: true
           receiveShadows: true
           executionSpeed: 0.5
+          roverRadius: 4
           sceneNode:
             get: |
               if ( !this.sceneNode ) {
@@ -381,6 +384,7 @@ children:
             properties:
               navmode: thirdPerson
               cameraPose: [ 16, 0, -15 ]
+              worldOffset: [ 0, 0, 1 ]
               cameraSpeed: 0
               usePoseFromCamera: true
           topDown:
@@ -433,6 +437,7 @@ children:
           castShadows: true
           receiveShadows: true
           executionSpeed: 0.5
+          roverRadius: 2
           surveyArray: []
           sceneNode:
             get: |
@@ -478,6 +483,7 @@ children:
             properties:
               navmode: thirdPerson
               cameraPose: [ 16, 0, -15 ]
+              worldOffset: [ 0, 0, 0.5 ]
               cameraSpeed: 0
               usePoseFromCamera: true
           topDown:
@@ -507,6 +513,7 @@ children:
           castShadows: true
           receiveShadows: true
           executionSpeed: 0.5
+          roverRadius: 7
           sceneNode:
             get: |
               if ( !this.sceneNode ) {
@@ -586,6 +593,7 @@ children:
             properties:
               navmode: thirdPerson
               cameraPose: [ 16, 0, -15 ]
+              worldOffset: [ 0, 0, 2 ]
               cameraSpeed: 0
               usePoseFromCamera: true
           topDown:

--- a/source/scene.js
+++ b/source/scene.js
@@ -283,6 +283,8 @@ this.displayTiles = function( isVisible ) {
     if ( isVisible !== tilesVisible ) {
         material.tilesVisible = isVisible ? 1 : 0;
         this.toggledTiles( isVisible );
+        // Should we switch to helicam view for the tiles as well?
+        // this.switchToHelicamView( isVisible );
     }
 }
 
@@ -293,6 +295,18 @@ this.displayGraph = function( isVisible ) {
         material.gridVisible = isVisible ? 1 : 0;
         this.toggledGraph( isVisible );
         this.blocklyGraph.blocklyLine.visible = isVisible;
+        this.switchToHelicamView( isVisible );
+    }
+}
+
+this.switchToHelicamView = function( bSwitch ) {
+    var targetNode, camera;
+    if ( bSwitch ) {
+        camera = this.gameCam;
+        targetNode = camera.target;
+        if ( targetNode.hasMount( "topDown" ) ) {
+            camera.setCameraMount( "topDown" );
+        }
     }
 }
 

--- a/source/scene.js
+++ b/source/scene.js
@@ -412,6 +412,7 @@ this.selectBlocklyNode = function( nodeID ) {
             }
             this.gameCam.setCameraTarget( node, mountName );
             this.hud.selectRover( nodeID );
+            this.selectedRover( node.roverRadius );
         } else if ( node === this.graph ) {
             this.gameCam.setCameraMount( "topDown" );
         }

--- a/source/view/index.js
+++ b/source/view/index.js
@@ -331,6 +331,10 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
                 setBriefInfo( title, content, imageSrc );
                 break;
 
+            case "selectedRover":
+                updateCameraDistance( eventArgs[ 0 ] );
+                break;
+
         } 
     } else {
         // scenario events

--- a/source/view/navigation.js
+++ b/source/view/navigation.js
@@ -326,4 +326,10 @@ function getFirstMesh( list ) {
     }
 }
 
+function updateCameraDistance( radius ) {
+    if ( !isNaN( radius ) ) {
+        thirdPerson_MinZoom = radius;
+    }
+}
+
 //@ sourceURL=source/navigation.js


### PR DESCRIPTION
@kadst43 @AmbientOSX @jyucra 

- Toggling on the graph now snaps to top down view
- Third person minimum zoom is based on `roverRadius` property of rover
- Added `worldOffset` to third person camera mounts so that the camera is pointed toward the middle of the rover, rather than the ground ( the rover's origin )