### PR TITLE
Disable hud

### DIFF
--- a/source/hud/marsGameHud.js
+++ b/source/hud/marsGameHud.js
@@ -29,7 +29,7 @@ this.setAllEnabled = function( value ) {
 this.elementPreDraw = function( context, element ) {
     var alpha = 1;
     var time = Date.now() / 1000;
-    if ( !element.enabled ) {
+    if ( !element.enabled || !this.enabled ) {
         alpha = 0.5;
     } else if ( element.isBlinking ) {
         if ( time  - element.lastBlinkTime > element.blinkInterval ) {

--- a/source/hud/marsGameHud.vwf.yaml
+++ b/source/hud/marsGameHud.vwf.yaml
@@ -18,7 +18,7 @@ implements:
   - http://vwf.example.com/sceneGetter.vwf
 properties:
   visible: true
-  enabled: false
+  enabled: true
 methods:
   elementPreDraw:
   elementPostDraw:

--- a/source/hud/marsGameHud.vwf.yaml
+++ b/source/hud/marsGameHud.vwf.yaml
@@ -18,6 +18,7 @@ implements:
   - http://vwf.example.com/sceneGetter.vwf
 properties:
   visible: true
+  enabled: false
 methods:
   elementPreDraw:
   elementPostDraw:

--- a/source/scenario/newmission3task1.vwf.yaml
+++ b/source/scenario/newmission3task1.vwf.yaml
@@ -131,6 +131,10 @@ children:
             - TM3VO3_MC
           - playSound:
             - TM3VO4_MC
+          - setProperty:
+            - hud
+            - enabled
+            - false
 
         openMissionBrief_3_1:
           triggerCondition:
@@ -141,6 +145,10 @@ children:
           - delay:
             - 54
             - openMissionBrief:
+            - setProperty:
+              - hud
+              - enabled
+              - true
 
         highlightEndTile:
           triggerCondition:

--- a/source/scenario/newmission3task2.vwf.yaml
+++ b/source/scenario/newmission3task2.vwf.yaml
@@ -127,6 +127,10 @@ children:
             - TM3VO5_Rover
           - playSound:
             - TM3VO6_MC
+          - setProperty:
+            - hud
+            - enabled
+            - false
 
         openMissionBrief_3_2:
           triggerCondition:
@@ -137,6 +141,10 @@ children:
           - delay:
             - 32
             - openMissionBrief:
+            - setProperty:
+              - hud
+              - enabled
+              - true
 
         highlightEndTile:
           triggerCondition:

--- a/source/scenario/newmission3task3.vwf.yaml
+++ b/source/scenario/newmission3task3.vwf.yaml
@@ -126,6 +126,10 @@ children:
             - TM3VO7_Rover
           - playSound:
             - TM3VO8_MC
+          - setProperty:
+            - hud
+            - enabled
+            - false
 
         openMissionBrief_3_3:
           triggerCondition:
@@ -136,6 +140,10 @@ children:
           - delay:
             - 24
             - openMissionBrief:
+            - setProperty:
+              - hud
+              - enabled
+              - true
 
         highlightEndTile:
           triggerCondition:

--- a/source/scenario/newmission3task4.vwf.yaml
+++ b/source/scenario/newmission3task4.vwf.yaml
@@ -126,6 +126,10 @@ children:
             - TM3VO9_Rover
           - playSound:
             - TM3V10_MC
+          - setProperty:
+            - hud
+            - enabled
+            - false
 
         openMissionBrief_3_4:
           triggerCondition:
@@ -136,6 +140,10 @@ children:
           - delay:
             - 19
             - openMissionBrief:
+            - setProperty:
+              - hud
+              - enabled
+              - true
 
         highlightEndTile:
           triggerCondition:

--- a/source/scenario/newmission3task5.vwf.yaml
+++ b/source/scenario/newmission3task5.vwf.yaml
@@ -130,6 +130,10 @@ children:
             - TM3V13_Rover
           - playSound:
             - TM3V14_MC
+          - setProperty:
+            - hud
+            - enabled
+            - false
 
         openMissionBrief_3_5:
           triggerCondition:
@@ -140,6 +144,10 @@ children:
           - delay:
             - 15
             - openMissionBrief:
+            - setProperty:
+              - hud
+              - enabled
+              - true
             
         highlightEndTile:
           triggerCondition:

--- a/source/scenario/newmission3task6.vwf.yaml
+++ b/source/scenario/newmission3task6.vwf.yaml
@@ -123,6 +123,10 @@ children:
             - TM3V15_Rover
           - playSound:
             - TM3V16_MC
+          - setProperty:
+            - hud
+            - enabled
+            - false
 
         openMissionBrief_3_6:
           triggerCondition:
@@ -133,6 +137,11 @@ children:
           - delay:
             - 10
             - openMissionBrief:
+            - setProperty:
+              - hud
+              - enabled
+              - true
+        
         highlightEndTile:
           triggerCondition:
           - onScenarioStart:

--- a/source/scenario/newmission3task7.vwf.yaml
+++ b/source/scenario/newmission3task7.vwf.yaml
@@ -120,6 +120,10 @@ children:
           actions:
           - playSound:
             - TM3V17_MC
+          - setProperty:
+            - hud
+            - enabled
+            - false
 
         openMissionBrief_3_7:
           triggerCondition:
@@ -130,6 +134,10 @@ children:
           - delay:
             - 11
             - openMissionBrief:
+            - setProperty:
+              - hud
+              - enabled
+              - true
 
         highlightEndTile:
           triggerCondition:


### PR DESCRIPTION
@kadst43 @AmbientOSX 

Unfortunately, I couldn't get the performance good enough for graying out the HUD. I tried everything I could think of to optimize it, but rendering it using the HTML Canvas every frame was just too slow. I had to fall back to using the same disable we use on the individual elements and just change the alpha if the entire hud is disabled.

Requires: https://github.com/virtual-world-framework/vwf/pull/509