### PR TITLE
hud-draw-order

### DIFF
--- a/source/hud/blocklyButton.js
+++ b/source/hud/blocklyButton.js
@@ -15,8 +15,6 @@
 this.draw = function( context, position ) {
     if ( this.icon ) {
         context.drawImage( this.icon, position.x, position.y );
-    } else {
-        this.icon.onload = function () { context.drawImage( this.icon, position.x, position.y ); };
     }
 }
 

--- a/source/hud/firstPersonButton.js
+++ b/source/hud/firstPersonButton.js
@@ -15,8 +15,6 @@
 this.draw = function( context, position ) {
     if ( this.icon ) {
         context.drawImage( this.icon, position.x, position.y );
-    } else {
-        this.icon.onload = function () { context.drawImage( this.icon, position.x, position.y ); };
     }
 }
 

--- a/source/hud/graphButton.js
+++ b/source/hud/graphButton.js
@@ -15,8 +15,6 @@
 this.draw = function( context, position ) {
     if ( this.icon ) {
         context.drawImage( this.icon, position.x, position.y );
-    } else {
-        this.icon.onload = function () { context.drawImage( this.icon, position.x, position.y ); };
     }
 }
 

--- a/source/hud/marsGameHud.vwf.yaml
+++ b/source/hud/marsGameHud.vwf.yaml
@@ -33,31 +33,59 @@ children:
   # TODO: Find a clever way to do this without being order restricted.
   batteryMeter:
     includes: source/hud/batteryMeter.vwf
+    properties:
+      drawOrder: 1
   blocklyButton:
     includes: source/hud/blocklyButton.vwf
+    properties:
+      drawOrder: 2
   graphButton:
     includes: source/hud/graphButton.vwf
+    properties:
+      drawOrder: 3
   tilesButton:
     includes: source/hud/tilesButton.vwf
+    properties:
+      drawOrder: 4
   missionButton:
     includes: source/hud/missionButton.vwf
+    properties:
+      drawOrder: 5
   optionsButton:
     includes: source/hud/optionsButton.vwf
+    properties:
+      drawOrder: 6
   objective:
     includes: source/hud/objective.vwf
+    properties:
+      drawOrder: 7
   comms:
     includes: source/hud/comms.vwf
+    properties:
+      drawOrder: 8
   cameraSelector:
     includes: source/hud/cameraSelector.vwf
+    properties:
+      drawOrder: 9
   firstPersonButton:
     includes: source/hud/firstPersonButton.vwf
+    properties:
+      drawOrder: 10
   thirdPersonButton:
     includes: source/hud/thirdPersonButton.vwf
+    properties:
+      drawOrder: 11
   topDownButton:
     includes: source/hud/topDownButton.vwf
+    properties:
+      drawOrder: 12
   alertDisplay:
     includes: source/hud/alertDisplay.vwf
+    properties:
+      drawOrder: 13
   roverSelector:
     includes: source/hud/roverSelector.vwf
+    properties:
+      drawOrder: 14
 scripts:
   - source: marsGameHud.js

--- a/source/hud/missionButton.js
+++ b/source/hud/missionButton.js
@@ -15,8 +15,6 @@
 this.draw = function( context, position ) {
     if ( this.icon ) {
         context.drawImage( this.icon, position.x, position.y );
-    } else {
-        this.icon.onload = function () { context.drawImage( this.icon, position.x, position.y ); };
     }
 }
 

--- a/source/hud/optionsButton.js
+++ b/source/hud/optionsButton.js
@@ -15,8 +15,6 @@
 this.draw = function( context, position ) {
     if ( this.icon ) {
         context.drawImage( this.icon, position.x, position.y );
-    } else {
-        this.icon.onload = function () { context.drawImage( this.icon, position.x, position.y ); };
     }
 }
 

--- a/source/hud/thirdPersonButton.js
+++ b/source/hud/thirdPersonButton.js
@@ -15,8 +15,6 @@
 this.draw = function( context, position ) {
     if ( this.icon ) {
         context.drawImage( this.icon, position.x, position.y );
-    } else {
-        this.icon.onload = function () { context.drawImage( this.icon, position.x, position.y ); };
     }
 }
 

--- a/source/hud/tilesButton.js
+++ b/source/hud/tilesButton.js
@@ -15,8 +15,6 @@
 this.draw = function( context, position ) {
     if ( this.icon ) {
         context.drawImage( this.icon, position.x, position.y );
-    } else {
-        this.icon.onload = function () { context.drawImage( this.icon, position.x, position.y ); };
     }
 }
 

--- a/source/hud/topDownButton.js
+++ b/source/hud/topDownButton.js
@@ -15,8 +15,6 @@
 this.draw = function( context, position ) {
     if ( this.icon ) {
         context.drawImage( this.icon, position.x, position.y );
-    } else {
-        this.icon.onload = function () { context.drawImage( this.icon, position.x, position.y ); };
     }
 }
 


### PR DESCRIPTION
@kadst43 @AmbientOSX 

I finally got the bug to occur and promptly dug into the objects to find that the automatic draw order of the HUD was failing us. We have the battery element listed in `marsGameHud.vwf` first so that it will be the first object created. We do this because it has some draw commands that work as a mask. Drawing it after the other elements would cause them to disappear. It turns out that some times the battery element doesn't get created quick enough by VWF and the next elements in the list jump ahead, causing their draw order to be before the battery element's mask. So, to remedy this, I've made it possible to explicitly set the draw order of the HUD elements and added their draw orders to the `marsGameHud.vwf` file.

Requires: https://github.com/virtual-world-framework/vwf/pull/512