### PR TITLE
Hide HUD During Instructional Dialog

### DIFF
--- a/source/hud/marsGameHud.js
+++ b/source/hud/marsGameHud.js
@@ -26,10 +26,22 @@ this.setAllEnabled = function( value ) {
     }
 }
 
+this.setAllVisible = function( value ) {
+    var elements = this.children;
+    for ( var i = 0; i < elements.length; i++ ) {
+        elements[ i ].visible = value;
+    }
+}
+
+this.isolateComms = function() {
+    this.setAllVisible( false );
+    this.comms.visible = true;
+}
+
 this.elementPreDraw = function( context, element ) {
     var alpha = 1;
     var time = Date.now() / 1000;
-    if ( !element.enabled || !this.enabled ) {
+    if ( !element.enabled ) {
         alpha = 0.5;
     } else if ( element.isBlinking ) {
         if ( time  - element.lastBlinkTime > element.blinkInterval ) {

--- a/source/hud/marsGameHud.vwf.yaml
+++ b/source/hud/marsGameHud.vwf.yaml
@@ -18,12 +18,22 @@ implements:
   - http://vwf.example.com/sceneGetter.vwf
 properties:
   visible: true
-  enabled: true
+  enabled:
+    set: |
+      if ( value ) {
+        this.setAllVisible( value );
+      } else {
+        this.isolateComms();
+      }
+      this.enabled = value;
+    value: true
 methods:
   elementPreDraw:
   elementPostDraw:
   setAllBlinking:
   setAllEnabled:
+  setAllVisible:
+  isolateComms:
   selectRover:
 children:
   # For now, the battery meter has to be drawn first, because


### PR DESCRIPTION
@kadst43 @AmbientOSX 

This now hides all of the HUD elements apart from the comms portraits at the beginning of missions.