### PR TITLE
Reopen Blockly Category

### DIFF
--- a/source/view/index.js
+++ b/source/view/index.js
@@ -256,6 +256,7 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
                 lastBlockIDExecuted = undefined;
                 currentProcedureBlockID = undefined;
                 lastBlockIDExecuted = undefined;
+                updateBlocklyUI( blocklyNodes[ currentBlocklyNodeID ] );
             case "scenarioReset":
                 removePopup();
                 removeFailScreen();
@@ -790,7 +791,7 @@ function getBlocklyNodeIDByName( name ) {
 }
 
 function updateBlocklyUI( blocklyNode ) {
-    if ( Blockly.mainWorkspace ) {
+    if ( Blockly.mainWorkspace && blocklyNode ) {
         Blockly.mainWorkspace.maxBlocks = blocklyNode.ramMax;
         if ( Blockly.mainWorkspace.toolbox_.tree_.firstChild_ !== undefined && ( currentScenario === 'Mission1Task1' || currentScenario === 'Mission1Task2' || currentScenario === 'Mission1Task3' || currentScenario === 'Mission1Task4' || currentScenario === 'Mission1Task5' || currentScenario === 'Mission1Task6' || currentScenario === 'Mission1Task7' || currentScenario === 'Mission1Task8' || currentScenario === 'Mission2Task1' || currentScenario === 'Mission2Task2' || currentScenario === 'Mission2Task3' ) ) {
             setTimeout( function() { 


### PR DESCRIPTION
Reopens the blockly tab when the scenario reloads the toolbox XML and adds a safety check for a Blockly node being present. I realize it would be nice to keep it open but Blockly recreates the toolbox tree when it loads new toolbox XML. I will look into changing this in the core.

@kadst43 