### PR TITLE
Suspend Renderer During Videos

### DIFF
--- a/index.vwf.yaml
+++ b/index.vwf.yaml
@@ -18,6 +18,7 @@ implements:
   - "http://vwf.example.com/blockly/manager.vwf"
   - "http://vwf.example.com/threejs/fogExp2.vwf"
 properties:
+  enableRenderer: true
   enableShadows: true
   shadowMapCullFace: "back"
   ambientColor: [ 70, 65, 65 ]

--- a/source/scenario/introCinematic.vwf.yaml
+++ b/source/scenario/introCinematic.vwf.yaml
@@ -29,6 +29,9 @@ children:
           triggerCondition:
           - onScenarioStart:
           actions:
+          - setSceneProperty:
+            - enableRenderer
+            - false
           - playVideo:
             - intro_cinematic
 
@@ -39,4 +42,7 @@ children:
           - onVideoPlayed:
             - intro_cinematic
           actions:
+          - setSceneProperty:
+            - enableRenderer
+            - true
           - scenarioSuccess:

--- a/source/scenario/mission1success.vwf.yaml
+++ b/source/scenario/mission1success.vwf.yaml
@@ -15,6 +15,9 @@ children:
           triggerCondition:
           - onScenarioStart:
           actions:
+          - setSceneProperty:
+            - enableRenderer
+            - false
           - stopAllSounds:
           - playVideo:
             - Success1
@@ -26,4 +29,7 @@ children:
           - onVideoPlayed:
             - Success1
           actions:
+          - setSceneProperty:
+            - enableRenderer
+            - true
           - scenarioSuccess:

--- a/source/scenario/mission2success.vwf.yaml
+++ b/source/scenario/mission2success.vwf.yaml
@@ -14,6 +14,9 @@ children:
           triggerCondition:
           - onScenarioStart:
           actions:
+          - setSceneProperty:
+            - enableRenderer
+            - false
           - stopAllSounds:
           - playVideo:
             - end_cinematic
@@ -25,4 +28,7 @@ children:
           - onVideoPlayed:
             - end_cinematic
           actions:
+          - setSceneProperty:
+            - enableRenderer
+            - true
           - scenarioSuccess:

--- a/source/scenario/mission3success.vwf.yaml
+++ b/source/scenario/mission3success.vwf.yaml
@@ -14,6 +14,9 @@ children:
           triggerCondition:
           - onScenarioStart:
           actions:
+          - setSceneProperty:
+            - enableRenderer
+            - false
           - stopAllSounds:
           - playVideo:
             - Success3
@@ -24,4 +27,7 @@ children:
           - onVideoPlayed:
             - Success3
           actions:
+          - setSceneProperty:
+            - enableRenderer
+            - true
           - scenarioSuccess:

--- a/source/scene.js
+++ b/source/scene.js
@@ -389,16 +389,6 @@ this.stopBlinkTab = function( nodeName ) {
     }
 }
 
-this.playVideo = function( src ) {
-    // var id = getVideoIdFromSrc( src );
-    // if ( isNaN( id ) || id < 0 || id >= videos.length ) {
-    //     id = loadVideo( src );
-    // }
-    $( "#transitionScreen" ).fadeIn( function(){ 
-        playVideo( src );
-    });
-}
-
 this.pauseGame = function() {
     this.paused();
 }
@@ -529,5 +519,8 @@ this.removeCalloutTile = function() {
     var material = this.environment.terrain.material;
     material.stopCallout();
 }
+
+// This method is being handled by the view
+this.playVideo = function( src ) {}
 
 //@ sourceURL=source/scene.js

--- a/source/view/index.js
+++ b/source/view/index.js
@@ -73,6 +73,26 @@ var blocklyDiv = document.getElementById('blocklyDiv');
 
 var cameraTargetPosition = [ 0, 0, 0 ];
 
+function getAppID() {
+    if ( appID === undefined ) {
+        appID = vwf_view.kernel.application();
+    }
+    return appID;
+}
+
+vwf_view.calledMethod = function( nodeID, methodName, methodParams ) {
+    if ( nodeID === getAppID() ) {
+        switch ( methodName ) {
+            case "playVideo":
+                var src = methodParams[ 0 ];
+                $( "#transitionScreen" ).fadeTo( 400, 1, function() {
+                    playVideo( src );
+                } );
+                break;
+        }
+    }
+}
+
 vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
     if ( blocklyNodes[ nodeID ] !== undefined ) {
         var blocklyNode = blocklyNodes[ nodeID ];
@@ -159,7 +179,7 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
                 break;
 
         }
-    } else if ( nodeID === vwf_view.kernel.application() ) {
+    } else if ( nodeID === getAppID() ) {
         switch ( eventName ) {
 
             case "paused":
@@ -302,7 +322,7 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
                 break;
 
             case "videoPlayed":
-                $( "#transitionScreen" ).fadeOut( function() {
+                $( "#transitionScreen" ).fadeTo( 400, 0, function() {
                     removeVideo();
                 } );
                 break;
@@ -428,8 +448,7 @@ vwf_view.createdNode = function( nodeID, childID, childExtendsID, childImplement
 }
 
 vwf_view.initializedNode = function( nodeID, childID, childExtendsID, childImplementsIDs, childSource, childType, childIndex, childName ) {
-    if ( childID === vwf_view.kernel.application() ) {
-        appID = vwf_view.kernel.application();
+    if ( childID === getAppID() ) {
         setUpView();
         threejs.render = render;
     } else if ( blocklyNodes[ childID ] !== undefined ) {
@@ -541,7 +560,7 @@ vwf_view.satProperty = function( nodeID, propertyName, propertyValue ) {
             var versionElem = document.getElementById( "version" );
             switch ( state ) {
                 case "loading":
-                    $( "#transitionScreen" ).fadeIn( 0 );
+                    $( "#transitionScreen" ).fadeTo( 0, 1 );
                     break;
                 case "menu":
                     loggerBox.style.display = "none";
@@ -549,14 +568,14 @@ vwf_view.satProperty = function( nodeID, propertyName, propertyValue ) {
                     versionElem.style.display = "block";
                     checkPageZoom();
                     timerWindow.style.display = "none";
-                    $( "#transitionScreen" ).fadeOut();
+                    $( "#transitionScreen" ).fadeTo( 400, 0 );
                     break;
                 case "playing":
                     mainMenu.setVisible( false );
                     versionElem.style.display = "none";
                     loggerBox.style.display = "block";
                     timerWindow.style.display = "block";
-                    $( "#transitionScreen" ).fadeOut();
+                    $( "#transitionScreen" ).fadeTo( 400, 0 );
                     break;
             }
         } else if ( propertyName === "roverTabBlinking" ) {

--- a/source/view/mainMenu.js
+++ b/source/view/mainMenu.js
@@ -84,8 +84,7 @@ MainMenu.prototype = {
     },
 
     playGame: function() {
-        var ts = document.getElementById( "transitionScreen" );
-        ts.style.display = "block";
+        $( "#transitionScreen" ).fadeTo( 0, 1 );
         vwf_view.kernel.callMethod( vwf_view.kernel.application(), "newGame" );
     },
 


### PR DESCRIPTION
@kadst43 @AmbientOSX 

Using David's change to suspend rendering, this stops rendering when each of the videos are playing. The increased performance also exacerbated the issue with the scene showing up before the intro video plays. I tried fixing it and only saw a very small improvement. However, the changes I made were good changes, so I left them in. I still am trying to find a way to solve that problem.

Let me know if the video performance is better now that rendering is suspended. Remember to update to the latest vwf/mars-game-development before testing.