### PR TITLE
Four Triangle Shader

### DIFF
--- a/source/scenario/mission4task1.vwf.yaml
+++ b/source/scenario/mission4task1.vwf.yaml
@@ -248,6 +248,7 @@ children:
             - onScenarioSucceeded:
             - onScenarioFailed:
           actions:
+          - clearTriangle:
           - setProperty:
             - rover2
             - surveyArray

--- a/source/scenario/mission4task2.vwf.yaml
+++ b/source/scenario/mission4task2.vwf.yaml
@@ -224,6 +224,7 @@ children:
             - onScenarioSucceeded:
             - onScenarioFailed:
           actions:
+          - clearTriangle:
           - setProperty:
             - rover2
             - surveyArray

--- a/source/scenario/mission4task3.vwf.yaml
+++ b/source/scenario/mission4task3.vwf.yaml
@@ -242,6 +242,7 @@ children:
             - onScenarioSucceeded:
             - onScenarioFailed:
           actions:
+          - clearTriangle:
           - setProperty:
             - rover2
             - surveyArray

--- a/source/scenario/mission4task4.vwf.yaml
+++ b/source/scenario/mission4task4.vwf.yaml
@@ -251,6 +251,7 @@ children:
             - onScenarioSucceeded:
             - onScenarioFailed:
           actions:
+          - clearTriangle:
           - setProperty:
             - rover2
             - surveyArray

--- a/source/scenario/mission4task5.vwf.yaml
+++ b/source/scenario/mission4task5.vwf.yaml
@@ -266,6 +266,7 @@ children:
             - onScenarioSucceeded:
             - onScenarioFailed:
           actions:
+          - clearTriangle:
           - setProperty:
             - rover2
             - surveyArray

--- a/source/scenario/mission4task6.vwf.yaml
+++ b/source/scenario/mission4task6.vwf.yaml
@@ -281,6 +281,7 @@ children:
             - onScenarioSucceeded:
             - onScenarioFailed:
           actions:
+          - clearTriangle:
           - setProperty:
             - rover2
             - surveyArray

--- a/source/scene.js
+++ b/source/scene.js
@@ -443,7 +443,12 @@ this.drawSchematicTriangle = function( pointA, pointB, pointC ) {
     // pointA, pointB, and pointC are in the format: [ x, y ]
     // x and y are in world space ( not grid coordinate space )
     var material = this.environment.terrain.material;
-    material.triangle = [ pointA, pointB, pointC ];
+    var triArray = material.triangle.slice();
+    if ( triArray.length >= 12 ) {
+        triArray = triArray.slice( 3 );
+    }
+    triArray.push( pointA, pointB, pointC );
+    material.triangle = triArray;
 }
 
 this.hideSchematicTriangle = function() {

--- a/source/shaders/mixMap.vwf.yaml
+++ b/source/shaders/mixMap.vwf.yaml
@@ -605,7 +605,26 @@ properties:
         }
       }
       #if MAX_TRIS > 0
-        if ( testTriangle( vWorldPosition.xy, triangle[ 0 ], triangle[ 1 ], triangle[ 2 ] ) ) {
+        bool inTriangle = false;
+        #if MAX_TRIS >= 3
+          inTriangle = testTriangle( vWorldPosition.xy, triangle[ 0 ], triangle[ 1 ], triangle[ 2 ] );
+        #endif
+        #if MAX_TRIS >= 6
+          if ( !inTriangle ) {
+            inTriangle = testTriangle( vWorldPosition.xy, triangle[ 3 ], triangle[ 4 ], triangle[ 5 ] );
+          }
+        #endif
+        #if MAX_TRIS >= 9
+          if ( !inTriangle ) {
+            inTriangle = testTriangle( vWorldPosition.xy, triangle[ 6 ], triangle[ 7 ], triangle[ 8 ] );
+          }
+        #endif
+        #if MAX_TRIS >= 12
+          if ( !inTriangle ) {
+            inTriangle = testTriangle( vWorldPosition.xy, triangle[ 9 ], triangle[ 10 ], triangle[ 11 ] );
+          }
+        #endif
+        if ( inTriangle ) {
           gl_FragColor.xyz += tileColor * 0.8;
         }
       #endif

--- a/source/triggers/actions/action_clearTriangle.js
+++ b/source/triggers/actions/action_clearTriangle.js
@@ -1,0 +1,35 @@
+// Copyright 2014 Lockheed Martin Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may 
+// not use this file except in compliance with the License. You may obtain 
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+this.onGenerated = function( params, generator, payload ) {
+    if ( !this.initAction( params, generator, payload ) ) {
+        return false;
+    }
+
+    if ( !params || ( params.length !== 0 ) ) {
+        this.logger.errorx( "onGenerated", 
+                            "This action does not take arguments." );
+    }
+
+    return true;
+}
+
+this.executeAction = function() {
+    var scene = this.scene;
+    if ( scene ) {
+        this.scene.hideSchematicTriangle();
+    }
+}
+
+//@ sourceURL=source/triggers/actions/action_clearTriangle.js

--- a/source/triggers/actions/action_clearTriangle.vwf.yaml
+++ b/source/triggers/actions/action_clearTriangle.vwf.yaml
@@ -1,0 +1,18 @@
+# Copyright 2014 Lockheed Martin Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. You may obtain 
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and 
+# limitations under the License.
+
+--- 
+extends: actionProto.vwf
+scripts:
+- source: action_clearTriangle.js

--- a/source/triggers/generators/generator_Action.vwf.yaml
+++ b/source/triggers/generators/generator_Action.vwf.yaml
@@ -119,6 +119,10 @@ properties:
     # arguments: vertex1, vertex2, vertex3
     drawTriangle: "source/triggers/actions/action_drawTriangle.vwf"
 
+    # Clears all drawn triangles
+    # arguments: none
+    clearTriangle: "source/triggers/actions/action_clearTriangle.vwf"
+
     # build a base component using our spiffy new shader
     # arguments: component name ( defined in index.vwf.yaml - must be added to scenario grid)
     buildBaseComponent: "source/triggers/actions/action_buildBaseComponent.vwf"


### PR DESCRIPTION
@kadst43 @AmbientOSX 

This allows up to 4 triangles to be drawn by the shader. In order to pass them in, you'll just have to add 3 more points to the `material.triangle` property.

`material.triangle = [ pa, pb, pc, pd, pe, pf ]` Would be 2 triangles, where pa, pb, and pc are the points of the first and pd, pe, and pf are the points of the second. Each point is of the format `[ x, y ]`. Anything beyond the 12th point will not be rendered by the shader.

I can go ahead and make changes to the code to make adding/managing points easier if you'd like. If so, I will wait until that is done before merging this.