### PR TITLE
Brett's Punchlist

### DIFF
--- a/source/scenario/mission4task1.vwf.yaml
+++ b/source/scenario/mission4task1.vwf.yaml
@@ -118,24 +118,20 @@ properties:
     - [ 21, -18, -10 ]
 
   #Solar panel construction
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task10.vwf.yaml
+++ b/source/scenario/mission4task10.vwf.yaml
@@ -118,13 +118,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -135,13 +130,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -152,13 +142,8 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 ,270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:
@@ -169,9 +154,8 @@ properties:
     - solarPanel4
     - rotation
     - [0 ,0 ,1 ,180 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task11.vwf.yaml
+++ b/source/scenario/mission4task11.vwf.yaml
@@ -118,13 +118,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -135,13 +130,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -152,13 +142,8 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 ,270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:
@@ -169,9 +154,8 @@ properties:
     - solarPanel4
     - rotation
     - [0 ,0 ,1 ,180 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task12.vwf.yaml
+++ b/source/scenario/mission4task12.vwf.yaml
@@ -119,13 +119,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -136,13 +131,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -153,13 +143,8 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 ,270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:
@@ -170,9 +155,8 @@ properties:
     - solarPanel4
     - rotation
     - [0 ,0 ,1 ,180 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task13.vwf.yaml
+++ b/source/scenario/mission4task13.vwf.yaml
@@ -113,13 +113,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -130,13 +125,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -147,13 +137,8 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 ,270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:
@@ -164,9 +149,8 @@ properties:
     - solarPanel4
     - rotation
     - [0 ,0 ,1 ,180 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task14.vwf.yaml
+++ b/source/scenario/mission4task14.vwf.yaml
@@ -139,13 +139,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -156,13 +151,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -173,13 +163,8 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 ,270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:
@@ -190,9 +175,8 @@ properties:
     - solarPanel4
     - rotation
     - [0 ,0 ,1 ,180 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:
@@ -205,13 +189,8 @@ properties:
     - isClosed
     - false
 
-  - setProperty:
+  - setConstructed:
     - marsTent1
-    - visible
-    - true
-  - setProperty:
-    - marsTent1
-    - built
     - true
 
 

--- a/source/scenario/mission4task15.vwf.yaml
+++ b/source/scenario/mission4task15.vwf.yaml
@@ -132,13 +132,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -149,13 +144,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -166,13 +156,8 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 ,270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:
@@ -183,9 +168,8 @@ properties:
     - solarPanel4
     - rotation
     - [0 ,0 ,1 ,180 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:
@@ -198,14 +182,12 @@ properties:
     - isClosed
     - false
 
-  - setProperty:
+  - setConstructed:
     - marsTent1
-    - visible
     - true
 
-  - setProperty:
+  - setConstructed:
     - greenhouse1
-    - visible
     - true
 
   - setProperty:

--- a/source/scenario/mission4task2.vwf.yaml
+++ b/source/scenario/mission4task2.vwf.yaml
@@ -103,24 +103,20 @@ properties:
     - 0
 
   # Solar panel construction
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task3.vwf.yaml
+++ b/source/scenario/mission4task3.vwf.yaml
@@ -103,24 +103,20 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false    
 
   - setProperty:

--- a/source/scenario/mission4task4.vwf.yaml
+++ b/source/scenario/mission4task4.vwf.yaml
@@ -117,28 +117,20 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
     - true
-  - setProperty:
-    - solarPanel1
-    - built
-    - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task5.vwf.yaml
+++ b/source/scenario/mission4task5.vwf.yaml
@@ -116,13 +116,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -133,19 +128,16 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task6.vwf.yaml
+++ b/source/scenario/mission4task6.vwf.yaml
@@ -119,13 +119,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -136,13 +131,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -153,14 +143,12 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 , 270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
     - false
 
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task7.vwf.yaml
+++ b/source/scenario/mission4task7.vwf.yaml
@@ -122,13 +122,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -139,13 +134,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -156,13 +146,8 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 ,270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:
@@ -173,9 +158,8 @@ properties:
     - solarPanel4
     - rotation
     - [0 ,0 ,1 ,180 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scenario/mission4task8.vwf.yaml
+++ b/source/scenario/mission4task8.vwf.yaml
@@ -124,13 +124,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -141,13 +136,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -158,13 +148,8 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 ,270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:
@@ -175,13 +160,8 @@ properties:
     - solarPanel4
     - rotation
     - [0 ,0 ,1 ,180 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:

--- a/source/scenario/mission4task9.vwf.yaml
+++ b/source/scenario/mission4task9.vwf.yaml
@@ -118,13 +118,8 @@ properties:
     - solarPanel1
     - scale
     - [.4, .4, .4]
-  - setProperty:
+  - setConstructed:
     - solarPanel1
-    - visible
-    - true
-  - setProperty:
-    - solarPanel1
-    - built
     - true
 
   - setProperty:
@@ -135,13 +130,8 @@ properties:
     - solarPanel2
     - rotation
     - [0 ,0 ,1 ,90 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel2
-    - visible
-    - true
-  - setProperty:
-    - solarPanel2
-    - built
     - true
 
   - setProperty:
@@ -152,13 +142,8 @@ properties:
     - solarPanel3
     - rotation
     - [0 ,0 ,1 ,270 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel3
-    - visible
-    - true
-  - setProperty:
-    - solarPanel3
-    - built
     - true
 
   - setProperty:
@@ -169,9 +154,8 @@ properties:
     - solarPanel4
     - rotation
     - [0 ,0 ,1 ,180 ]
-  - setProperty:
+  - setConstructed:
     - solarPanel4
-    - visible
     - false
 
   - setProperty:

--- a/source/scene.js
+++ b/source/scene.js
@@ -90,6 +90,7 @@ this.setScenario = function( path ) {
         if ( scenario ) {
             this.activeScenarioPath = path;
             this.clearWatchList();
+            this.removeCalloutTile();
             // TODO: pass the scenario, not the name.  Or else just send the 
             //  event without looking the scenario itself up.  Or assert that 
             //  the scenario exists.  Or something.

--- a/source/scene.js
+++ b/source/scene.js
@@ -91,6 +91,7 @@ this.setScenario = function( path ) {
             this.activeScenarioPath = path;
             this.clearWatchList();
             this.removeCalloutTile();
+            this.hideSchematicTriangle();
             // TODO: pass the scenario, not the name.  Or else just send the 
             //  event without looking the scenario itself up.  Or assert that 
             //  the scenario exists.  Or something.

--- a/source/scene.js
+++ b/source/scene.js
@@ -375,7 +375,7 @@ this.resetView = function() {
 this.cameraMounted = function( mountName ) {
     var activeNode;
     activeNode = this.findByID( this, this.blockly_activeNodeID );
-    if ( Boolean( activeNode.facingArrow ) ) {
+    if ( activeNode && activeNode.facingArrow ) {
         if ( mountName === "topDown" ) {
             activeNode.facingArrow.visible = true;
         } else {
@@ -385,7 +385,7 @@ this.cameraMounted = function( mountName ) {
 }
 
 this.targetSwitched = function( oldTarget, newTarget ) {
-    if ( Boolean( oldTarget.facingArrow ) ) {
+    if ( oldTarget && oldTarget.facingArrow ) {
         oldTarget.facingArrow.visible = false;
     }
 }

--- a/source/shaders/mixMap.vwf.yaml
+++ b/source/shaders/mixMap.vwf.yaml
@@ -644,8 +644,8 @@ properties:
 methods:
   callout: |
     var highlight = this.calloutHighlight;
-    this.calloutHighlight = highlight === 0 ? 1 : 0;
     if ( this.bCallout$ ) {
+      this.calloutHighlight = highlight === 0 ? 1 : 0;
       this.future( 0.25 ).callout();
     }
   stopCallout: |

--- a/source/triggers/actions/action_setConstructed.js
+++ b/source/triggers/actions/action_setConstructed.js
@@ -1,0 +1,44 @@
+// Copyright 2014 Lockheed Martin Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may 
+// not use this file except in compliance with the License. You may obtain 
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+this.onGenerated = function( params, generator, payload ) {
+    if ( !this.initAction( params, generator, payload ) ) {
+        return false;
+    }
+
+    if ( !params || ( params.length !== 2 ) ) {
+        this.logger.errorx( "onGenerated", 
+                            "This action takes two arguments: the path of " +
+                            "the object to be modified and a boolean determining " +
+                            "whether it will be built or hidden." );
+        return false;
+    }
+
+    this.objectName = params[ 0 ];
+    this.value = params[ 1 ];
+
+    return true;
+}
+
+this.executeAction = function() {
+    var object = this.findInScene( this.objectName );
+
+    this.assert( object, "Object not found!" );
+
+    if ( object && object.setConstructed ) {
+        object.setConstructed( this.value );
+    }
+}
+
+//@ sourceURL=source/triggers/actions/action_setConstructed.js

--- a/source/triggers/actions/action_setConstructed.vwf.yaml
+++ b/source/triggers/actions/action_setConstructed.vwf.yaml
@@ -1,0 +1,23 @@
+# Copyright 2014 Lockheed Martin Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. You may obtain 
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and 
+# limitations under the License.
+
+--- 
+extends: actionProto.vwf
+
+properties:
+  objectName:
+  value:
+
+scripts:
+- source: action_setConstructed.js

--- a/source/triggers/generators/generator_Action.vwf.yaml
+++ b/source/triggers/generators/generator_Action.vwf.yaml
@@ -127,6 +127,10 @@ properties:
     # arguments: component name ( defined in index.vwf.yaml - must be added to scenario grid)
     buildBaseComponent: "source/triggers/actions/action_buildBaseComponent.vwf"
 
+    # Set a base component to constructed or hidden
+    # arguments: component name, value
+    setConstructed: "source/triggers/actions/action_setConstructed.vwf"
+
     # open the mission brief for the current scenario
     # arguments: none
     openMissionBrief: "source/triggers/actions/action_openMissionBrief.vwf"

--- a/source/view/missionBrief.css
+++ b/source/view/missionBrief.css
@@ -30,7 +30,7 @@
     position: absolute;
     top: 15%;
     width: 750px;
-    height: 600px;
+    height: 450px;
     font-size: 0px; /* Remove spacing between divs */
     border: 2px solid rgb( 210, 235, 255 );
     border-top-right-radius: 8px;
@@ -42,10 +42,10 @@
 #mb_image {
     background-image: url( "../../assets/images/briefBG.png" );
     background-color: rgb( 0, 0, 0 );
-    background-position: center;
+    background-position: center center;
     background-repeat: no-repeat;
     width: 150px;
-    height: 600px;
+    height: 450px;
     border-top-left-radius: 32px;
     border-bottom-left-radius: 8px;
 }
@@ -53,7 +53,7 @@
 #mb_main {
     background-color: rgb( 25, 25, 25 );
     width: 600px;
-    height: 600px;
+    height: 450px;
     border-top-right-radius: 8px;
     border-bottom-right-radius: 32px;
 }
@@ -76,8 +76,9 @@
     text-align: justify;
     color: rgb( 255, 245, 175 );
     width: 576px;
-    height: 496px;
+    height: 346px;
     padding: 12px;
+    overflow-y: scroll;
 }
 
 #mb_continue {


### PR DESCRIPTION
@kadst43 @AmbientOSX @jyucra 

- Made the mission brief window shorter for smaller resolution screens. The contents now have the ability to scroll.
- Fixed a console warning caused by the rover facing arrow changes.
- Added `setConstructed` action for immediately setting base components to constructed or hidden.
- Modified Mission 4 to use `setConstructed` action to fix objects that should be built not appearing.
- Fixed bug where blinking tiles would stay lit up after scenario changed.
- Fixed bug where highlighted tiles and triangles would stay visible when switching to a scenario without them.