### PR TITLE
Fix Camera Jitter

### DIFF
--- a/source/gameCamera.js
+++ b/source/gameCamera.js
@@ -55,7 +55,7 @@ this.followTarget = function( transform ) {
         newTransform[ 12 ] += transform[ 12 ] - this.lastTargetPosition[ 0 ];
         newTransform[ 13 ] += transform[ 13 ] - this.lastTargetPosition[ 1 ];
         newTransform[ 14 ] += transform[ 14 ] - this.lastTargetPosition[ 2 ];
-        this.transformTo( newTransform );
+        this.transform = newTransform;
     }
     this.lastTargetPosition = [
         transform[ 12 ],


### PR DESCRIPTION
@kadst43 @AmbientOSX @eric79 

So, it turns out that if you use the `transformTo` method without a duration, the threejs view driver skips interpolation of that transform. I opted to go with setting the property rather than adding a duration, since the duration can cause repeated transforms to get jammed up if it is too long and look jumpy if it's too short. This fixes the camera jitter when following the target node, however, if the app is running slowly, you'll notice some lag/fighting when controlling the camera while it is following the target node.