### PR TITLE
Fix action + add view functions for camera setting

### DIFF
--- a/index.vwf.yaml
+++ b/index.vwf.yaml
@@ -97,6 +97,8 @@ methods:
   calloutTile:
   removeCalloutTile:
   hideUI:
+  setActiveRoverPose:
+  printCameraPose:
 events:
   gameStarted:
   scenarioReset:

--- a/source/scene.js
+++ b/source/scene.js
@@ -360,6 +360,13 @@ this.setCinematicView = function( pose ) {
     }
 }
 
+this.setActiveRoverPose = function( pose ) {
+    var rover = this.findByID( this, this.blockly_activeNodeID );
+    if ( rover && rover.thirdPerson ) {
+        rover.thirdPerson.cameraPose = pose;
+    }
+}
+
 this.resetView = function() {
     var camera = this.player.targetFollower.camera;
     if ( lastCameraPOV === camera.pointOfView ) {
@@ -595,5 +602,10 @@ this.removeCalloutTile = function() {
 
 // This method is being handled by the view
 this.playVideo = function( src ) {}
+
+this.printCameraPose = function() {
+    var pose = this.gameCam.getPoseFromTransform();
+    console.log( "Camera pose: [ " + pose[ 0 ] + ", " + pose[ 1 ] + ", " + pose[ 2 ] + " ]" );
+}
 
 //@ sourceURL=source/scene.js

--- a/source/triggers/actions/action_setThirdPersonStartPose.js
+++ b/source/triggers/actions/action_setThirdPersonStartPose.js
@@ -35,8 +35,7 @@ this.onGenerated = function( params, generator, payload ) {
 }
 
 this.executeAction = function() {
-    // TODO: Should we be looking this up instead of hardcoding the path?
-    this.scene.player.rover.thirdPerson.cameraPose = this.pose;
+    this.scene.setActiveRoverPose( this.pose.slice() );
 }
 
 //@ sourceURL=source/triggers/actions/action_setThirdPersonStartPose.js

--- a/source/view/index.js
+++ b/source/view/index.js
@@ -1548,6 +1548,15 @@ function formatTime( time ) {
     return formattedTime;
 }
 
+function readCameraPose() {
+    vwf_view.kernel.callMethod( getAppID(), "printCameraPose" );
+}
+
+function writeCameraPose( radius, yaw, pitch ) {
+    var pose = [ radius, yaw, pitch ];
+    vwf_view.kernel.callMethod( getAppID(), "setCinematicView", [ pose ] );
+}
+
 window.addEventListener( "resize", checkPageZoom );
 
 //@ sourceURL=source/view/index.js


### PR DESCRIPTION
@kadst43 

I left the change to that action in there. Haven't determined if it is obsolete yet.

Edit: `readCameraPose()` will display the current pose in `[ radius, yaw, pitch ]` and `writeCameraPose( radius, yaw, pitch )` can be used to set the camera pose (you can also move it with the mouse, of course, but this way you can test cleaner numbers).