### PR TITLE
Fix for blinking tab in mission 2 task 2

### DIFF
--- a/source/scenario/mission2task2.vwf.yaml
+++ b/source/scenario/mission2task2.vwf.yaml
@@ -27,8 +27,6 @@ properties:
     - environmentWind
   - blinkHUDElement:
     - blocklyButton
-  - blinkBlocklyTab:
-    - graph
   - setObjective:
     - "Open the GRAPH tab in your PROGRAM interface."
   - setThirdPersonStartPose:
@@ -157,6 +155,8 @@ children:
           actions:
           - stopBlinkHUDElement:
             - blocklyButton
+          - blinkBlocklyTab:
+            - graph
 
         playHint1_2b:
           triggerCondition:


### PR DESCRIPTION
@kadst43 @AmbientOSX 

I didn't dig into this one. On a hunch, I assumed the way we're defining what tabs we use in the scenarios now is clearing the tabs and the blinking after we tell it to make the tab blink, so I moved the blink call to after the blockly window is opened. I tested it and it worked, but I cannot verify that my hunch is correct, only that this solution worked. Hope that's good enough for now. If not, I will dig into it further.