### PR TITLE
No alerts + helicam radius

### DIFF
--- a/source/hud/marsGameHud.vwf.yaml
+++ b/source/hud/marsGameHud.vwf.yaml
@@ -85,10 +85,10 @@ children:
     includes: source/hud/topDownButton.vwf
     properties:
       drawOrder: 12
-  alertDisplay:
-    includes: source/hud/alertDisplay.vwf
-    properties:
-      drawOrder: 13
+  # alertDisplay:
+  #   includes: source/hud/alertDisplay.vwf
+  #   properties:
+  #     drawOrder: 13
   # roverSelector:
   #   includes: source/hud/roverSelector.vwf
   #   properties:

--- a/source/rover.js
+++ b/source/rover.js
@@ -399,40 +399,40 @@ this.allowedBlocksChanged = function( value ) {
 }
 
 this.ramChanged = function( value ) {
-    var scene = this.scene;
-    if ( scene !== undefined && scene.alerts ) {
-        if ( value <= this.lowRam ) {
-            if ( value <= 0 ) {
-                scene.addAlert( this.displayName + " is Out of Memory" );
-            } else {
-                scene.addAlert( this.displayName + " is Low on Memory" );
-            }
-        }
-    }
+    // var scene = this.scene;
+    // if ( scene !== undefined && scene.alerts ) {
+    //     if ( value <= this.lowRam ) {
+    //         if ( value <= 0 ) {
+    //             scene.addAlert( this.displayName + " is Out of Memory" );
+    //         } else {
+    //             scene.addAlert( this.displayName + " is Low on Memory" );
+    //         }
+    //     }
+    // }
 }
 
 this.batteryChanged = function( value ) {
-    var scene = this.scene;
-    if ( scene !== undefined && scene.alerts ) {
-        if ( value < this.lowBattery ) {
-            if ( value <= 0 ) {
-                scene.addAlert( this.displayName + " is Out of Power" );
-            } else {
-                scene.addAlert( this.displayName + " is Low on Power" );
-            }
-        }
-    }
+    // var scene = this.scene;
+    // if ( scene !== undefined && scene.alerts ) {
+    //     if ( value < this.lowBattery ) {
+    //         if ( value <= 0 ) {
+    //             scene.addAlert( this.displayName + " is Out of Power" );
+    //         } else {
+    //             scene.addAlert( this.displayName + " is Low on Power" );
+    //         }
+    //     }
+    // }
 }
 
 this.moveFailed = function( value ) {
-    var scene = this.scene;
-    if ( scene !== undefined && scene.alerts ) {
-        switch( value ) {
-            case 'collision':
-                scene.addAlert( this.displayName + " is Blocked" );
-                break;
-        }
-    }
+    // var scene = this.scene;
+    // if ( scene !== undefined && scene.alerts ) {
+    //     switch( value ) {
+    //         case 'collision':
+    //             scene.addAlert( this.displayName + " is Blocked" );
+    //             break;
+    //     }
+    // }
 }
 
 this.activateSensor = function( sensor, value ) {

--- a/source/view/navigation.js
+++ b/source/view/navigation.js
@@ -20,7 +20,7 @@ var defaultNav = {
 }
 
 var thirdPerson_ZoomLevel;
-var topDown_controlRadius = 24;
+var topDown_controlRadius = 30;
 
 // Zoom bounds in meters
 var topDown_MaxAltitude = 100;


### PR DESCRIPTION
@kadst43 @AmbientOSX 

Remove alerts and extend helicam radius so that you can pan to see the radio at the default zoom level.