### PR TITLE
Remove scene flash

### DIFF
--- a/index.vwf.html
+++ b/index.vwf.html
@@ -84,7 +84,7 @@ limitations under the License.
 <!-- Misc -->
 <div id="version"></div>
 <div id="zoomAlert"></div>
-<div id="videoScreen"></div>
+<div id="vidScreen"></div>
 <div id="transitionScreen"></div>
 
 <!-- Pause Menu -->

--- a/index.vwf.html
+++ b/index.vwf.html
@@ -84,6 +84,7 @@ limitations under the License.
 <!-- Misc -->
 <div id="version"></div>
 <div id="zoomAlert"></div>
+<div id="videoScreen"></div>
 <div id="transitionScreen"></div>
 
 <!-- Pause Menu -->

--- a/source/view/index.css
+++ b/source/view/index.css
@@ -456,7 +456,7 @@ a:active {
     bottom: 0px;
 }
 
-#videoScreen {
+#vidScreen {
     height: 100%;
     width: 100%;
     position: absolute;
@@ -465,6 +465,7 @@ a:active {
     background-color: #000;
     z-index: 102;
     pointer-events: none;
+    display: none;
 }
 
 #pauseScreen {

--- a/source/view/index.css
+++ b/source/view/index.css
@@ -456,6 +456,17 @@ a:active {
     bottom: 0px;
 }
 
+#videoScreen {
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: #000;
+    z-index: 102;
+    pointer-events: none;
+}
+
 #pauseScreen {
     position: absolute;
     top: 0px;

--- a/source/view/index.js
+++ b/source/view/index.js
@@ -88,7 +88,7 @@ vwf_view.calledMethod = function( nodeID, methodName, methodParams ) {
         switch ( methodName ) {
             case "playVideo":
                 var src = methodParams[ 0 ];
-                $( "#transitionScreen" ).fadeTo( 400, 1, function() {
+                $( "#videoScreen" ).fadeTo( 400, 1, function() {
                     playVideo( src );
                 } );
                 break;
@@ -412,7 +412,7 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
                 break;
 
             case "videoPlayed":
-                $( "#transitionScreen" ).fadeTo( 400, 0, function() {
+                $( "#videoScreen" ).fadeTo( 400, 0, function() {
                     removeVideo();
                 } );
                 break;

--- a/source/view/index.js
+++ b/source/view/index.js
@@ -88,7 +88,7 @@ vwf_view.calledMethod = function( nodeID, methodName, methodParams ) {
         switch ( methodName ) {
             case "playVideo":
                 var src = methodParams[ 0 ];
-                $( "#videoScreen" ).fadeTo( 400, 1, function() {
+                $( "#vidScreen" ).fadeTo( 0, 1, function() {
                     playVideo( src );
                 } );
                 break;
@@ -412,7 +412,7 @@ vwf_view.firedEvent = function( nodeID, eventName, eventArgs ) {
                 break;
 
             case "videoPlayed":
-                $( "#videoScreen" ).fadeTo( 400, 0, function() {
+                $( "#vidScreen" ).fadeTo( 400, 0, function() {
                     removeVideo();
                 } );
                 break;


### PR DESCRIPTION
@kadst43 @AmbientOSX 

This should remove the scene flashing at the start of the game. It also causes us to immediately cut to videos, though. So the 400ms fade in doesn't happen. I don't think it looks bad. Definitely the benefit outweighs the cost.